### PR TITLE
Recommend to install client globally.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -7,7 +7,7 @@
 ## Installation
 
 ```sh
-npm install --save neovim-client
+npm install --global neovim-client
 ```
 
 ## Usage


### PR DESCRIPTION
Saving it to a particular project would make meaningless copies of the client code (unless the user uses the `link` option`). This allows one copy to be used everywhere.