### PR TITLE
Promise based API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ before_install:
   - eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
 
 node_js:
-- '0.12'
-- '0.10'
+  - 'stable'
+  - '0.12'
+  - '0.10'

--- a/README.mkd
+++ b/README.mkd
@@ -13,7 +13,7 @@ npm install --global neovim-client
 ## Usage
 
 This package exports a single `attach()` function which takes a pair of
-write/read streams and invokes a callback with a Nvim API object. This is
+write/read streams and returns a promise of Nvim API object. This is
 similar to [node-msgpack5rpc](https://github.com/tarruda/node-msgpack5rpc), but
 it provides an automatically generated API.
 
@@ -21,11 +21,10 @@ Examples:
 
 ```js
 var cp = require('child_process');
-var attach = require('neovim-client');
+var attach = require('promised-neovim-client').attach;
 
 var nvim_proc = cp.spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {});
-attach(nvim_proc.stdin, nvim_proc.stdout, function(err, nvim) {
-
+attach(nvim_proc.stdin, nvim_proc.stdout).then(function(nvim) {
   nvim.on('request', function(method, args, resp) {
     // handle msgpack-rpc request
   });
@@ -34,43 +33,44 @@ attach(nvim_proc.stdin, nvim_proc.stdout, function(err, nvim) {
     // handle msgpack-rpc notification
   });
 
-  nvim.command('vsp', function(err, res) {
-    nvim.getWindows(function(err, windows) {
+  nvim
+    .command('vsp')
+    .then(() => nvim.getWindows())
+    .then(windows => {
       console.log(windows.length);  // 2
       console.log(windows[0] instanceof nvim.Window); // true
       console.log(windows[1] instanceof nvim.Window); // true
-      nvim.setCurrentWindow(windows[1], function(err, res) {
-        nvim.getCurrentWindow(function(err, win) {
+      return nvim.setCurrentWindow(windows[1])
+        .then(() => nvim.getCurrentWindow())
+        .then(win => {
           console.log(win.equals(windows[1]))  // true
           nvim.quit();
-          nvim.on('disconnect', function() {
-            console.log("Nvim exited!");
-          });
+          nvim.on('disconnect', () => console.log("Nvim exited!"));
         });
-      });
-    });
-  });
-});
+    }).catch(err => console.log(err.message));
+
+}).catch(err => console.log(err.message));
 ```
 
 Methods are attached to buffers, windows and tabpages according to the
 msgpack-rpc name:
 
 ```js
-nvim.getCurrentBuffer(function(err, buf) {
-  console.log(buf instanceof nvim.Buffer);  // true
-  buf.getLineSlice(0, -1, true, true, function(err, lines) {
-    console.log(lines);  // ['']
-    buf.setLineSlice(0, -1, true, true, ['line1', 'line2'], function(err) {
-      buf.getLineSlice(0, -1, true, true, function(err, lines) {
-        console.log(lines);  // ['line1', 'line2']
-      });
-    });
+nvim
+  .getCurrentBuffer()
+  .then(buf => {
+    console.log(buf instanceof nvim.Buffer);  // true
+    return buf
+      .getLineSlice(0, -1, true, true);
+      .then(lines => {
+        console.log(lines);  // ['']
+        return buf.setLineSlice(0, -1, true, true, ['line1', 'line2']);
+      }).then(() => getLineSlice(0, -1, true, true))
+      .then(lines => console.log(lines))  // ['line1', 'line2']
   });
-});
 ```
 
-A [typescript declaration file](api.d.ts) is available as documentation of the
+A [typescript declaration file](index.d.ts) is available as documentation of the
 API and also for typescript users that seek to use this library. Note that the
 interfaces are [automatically generated](generate-typescript-interfaces.js) at a
 certain point in time, and may not correspond exactly to the API of your

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,83 +1,83 @@
-declare module "neovim-client" {
-  export default attach;
-  function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void);
-
-  interface Nvim {
-    command(str: string, cb: (err: Error) => void): void;
-    feedkeys(keys: string, mode: string, escape_csi: boolean, cb: (err: Error) => void): void;
-    input(keys: string, cb: (err: Error, res: number) => void): void;
-    replaceTermcodes(str: string, from_part: boolean, do_lt: boolean, special: boolean, cb: (err: Error, res: string) => void): void;
-    commandOutput(str: string, cb: (err: Error, res: string) => void): void;
-    eval(str: string, cb: (err: Error, res: Object) => void): void;
-    callFunction(fname: string, args: Array<any>, cb: (err: Error, res: Object) => void): void;
-    strwidth(str: string, cb: (err: Error, res: number) => void): void;
-    listRuntimePaths(cb: (err: Error, res: Array<string>) => void): void;
-    changeDirectory(dir: string, cb: (err: Error) => void): void;
-    getCurrentLine(cb: (err: Error, res: string) => void): void;
-    setCurrentLine(line: string, cb: (err: Error) => void): void;
-    delCurrentLine(cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    getVvar(name: string, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    outWrite(str: string, cb: (err: Error) => void): void;
-    errWrite(str: string, cb: (err: Error) => void): void;
-    reportError(str: string, cb: (err: Error) => void): void;
-    getBuffers(cb: (err: Error, res: Array<Buffer>) => void): void;
-    getCurrentBuffer(cb: (err: Error, res: Buffer) => void): void;
-    setCurrentBuffer(buffer: Buffer, cb: (err: Error) => void): void;
-    getWindows(cb: (err: Error, res: Array<Window>) => void): void;
-    getCurrentWindow(cb: (err: Error, res: Window) => void): void;
-    setCurrentWindow(window: Window, cb: (err: Error) => void): void;
-    getTabpages(cb: (err: Error, res: Array<Tabpage>) => void): void;
-    getCurrentTabpage(cb: (err: Error, res: Tabpage) => void): void;
-    setCurrentTabpage(tabpage: Tabpage, cb: (err: Error) => void): void;
-    subscribe(event: string, cb: (err: Error) => void): void;
-    unsubscribe(event: string, cb: (err: Error) => void): void;
-    nameToColor(name: string, cb: (err: Error, res: number) => void): void;
-    getColorMap(cb: (err: Error, res: {}) => void): void;
-    getApiInfo(cb: (err: Error, res: Array<any>) => void): void;
-  }
-  interface Buffer {
-    lineCount(cb: (err: Error, res: number) => void): void;
-    getLine(index: number, cb: (err: Error, res: string) => void): void;
-    setLine(index: number, line: string, cb: (err: Error) => void): void;
-    delLine(index: number, cb: (err: Error) => void): void;
-    getLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, cb: (err: Error, res: Array<string>) => void): void;
-    setLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, replacement: Array<string>, cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    getNumber(cb: (err: Error, res: number) => void): void;
-    getName(cb: (err: Error, res: string) => void): void;
-    setName(name: string, cb: (err: Error) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-    insert(lnum: number, lines: Array<string>, cb: (err: Error) => void): void;
-    getMark(name: string, cb: (err: Error, res: Array<number>) => void): void;
-  }
-  interface Window {
-    getBuffer(cb: (err: Error, res: Buffer) => void): void;
-    getCursor(cb: (err: Error, res: Array<number>) => void): void;
-    setCursor(pos: Array<number>, cb: (err: Error) => void): void;
-    getHeight(cb: (err: Error, res: number) => void): void;
-    setHeight(height: number, cb: (err: Error) => void): void;
-    getWidth(cb: (err: Error, res: number) => void): void;
-    setWidth(width: number, cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    getPosition(cb: (err: Error, res: Array<number>) => void): void;
-    getTabpage(cb: (err: Error, res: Tabpage) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-  }
-  interface Tabpage {
-    getWindows(cb: (err: Error, res: Array<Window>) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    getWindow(cb: (err: Error, res: Window) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-  }
+export interface Nvim extends NodeJS.EventEmitter {
+  uiAttach(width: number, height: number, rgb: true, cb?: Function): void;
+  uiDetach(cb?: Function): void;
+  uiTryResize(width: number, height: number, cb?: Function): void;
+  command(str: string): Promise<void>;
+  feedkeys(keys: string, mode: string, escape_csi: boolean): Promise<void>;
+  input(keys: string): Promise<number>;
+  replaceTermcodes(str: string, from_part: boolean, do_lt: boolean, special: boolean): Promise<string>;
+  commandOutput(str: string): Promise<string>;
+  eval(str: string): Promise<Object>;
+  callFunction(fname: string, args: Array<any>): Promise<Object>;
+  strwidth(str: string): Promise<number>;
+  listRuntimePaths(): Promise<Array<string>>;
+  changeDirectory(dir: string): Promise<void>;
+  getCurrentLine(): Promise<string>;
+  setCurrentLine(line: string): Promise<void>;
+  delCurrentLine(): Promise<void>;
+  getVar(name: string): Promise<Object>;
+  setVar(name: string, value: Object): Promise<Object>;
+  getVvar(name: string): Promise<Object>;
+  getOption(name: string): Promise<Object>;
+  setOption(name: string, value: Object): Promise<void>;
+  outWrite(str: string): Promise<void>;
+  errWrite(str: string): Promise<void>;
+  reportError(str: string): Promise<void>;
+  getBuffers(): Promise<Array<Buffer>>;
+  getCurrentBuffer(): Promise<Buffer>;
+  setCurrentBuffer(buffer: Buffer): Promise<void>;
+  getWindows(): Promise<Array<Window>>;
+  getCurrentWindow(): Promise<Window>;
+  setCurrentWindow(window: Window): Promise<void>;
+  getTabpages(): Promise<Array<Tabpage>>;
+  getCurrentTabpage(): Promise<Tabpage>;
+  setCurrentTabpage(tabpage: Tabpage): Promise<void>;
+  subscribe(event: string): Promise<void>;
+  unsubscribe(event: string): Promise<void>;
+  nameToColor(name: string): Promise<number>;
+  getColorMap(): Promise<Object>;
+  getApiInfo(): Promise<Array<any>>;
 }
+export interface Buffer {
+  lineCount(): Promise<number>;
+  getLine(index: number): Promise<string>;
+  setLine(index: number, line: string): Promise<void>;
+  delLine(index: number): Promise<void>;
+  getLineSlice(start: number, end: number, include_start: boolean, include_end: boolean): Promise<Array<string>>;
+  setLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, replacement: Array<string>): Promise<void>;
+  getVar(name: string): Promise<Object>;
+  setVar(name: string, value: Object): Promise<Object>;
+  getOption(name: string): Promise<Object>;
+  setOption(name: string, value: Object): Promise<void>;
+  getNumber(): Promise<number>;
+  getName(): Promise<string>;
+  setName(name: string): Promise<void>;
+  isValid(): Promise<boolean>;
+  insert(lnum: number, lines: Array<string>): Promise<void>;
+  getMark(name: string): Promise<Array<number>>;
+}
+export interface Window {
+  getBuffer(): Promise<Buffer>;
+  getCursor(): Promise<Array<number>>;
+  setCursor(pos: Array<number>): Promise<void>;
+  getHeight(): Promise<number>;
+  setHeight(height: number): Promise<void>;
+  getWidth(): Promise<number>;
+  setWidth(width: number): Promise<void>;
+  getVar(name: string): Promise<Object>;
+  setVar(name: string, value: Object): Promise<Object>;
+  getOption(name: string): Promise<Object>;
+  setOption(name: string, value: Object): Promise<void>;
+  getPosition(): Promise<Array<number>>;
+  getTabpage(): Promise<Tabpage>;
+  isValid(): Promise<boolean>;
+}
+export interface Tabpage {
+  getWindows(): Promise<Array<Window>>;
+  getVar(name: string): Promise<Object>;
+  setVar(name: string, value: Object): Promise<Object>;
+  getWindow(): Promise<Window>;
+  isValid(): Promise<boolean>;
+}
+export declare var attach: (writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream) => Promise<Nvim>;
+

--- a/package.json
+++ b/package.json
@@ -1,27 +1,34 @@
 {
-  "name": "neovim-client",
-  "description": "Neovim client library",
-  "version": "1.0.5",
+  "name": "promised-neovim-client",
+  "description": "Promised Neovim client library for modern JavaScript",
+  "version": "0.1.8",
   "homepage": "https://github.com/neovim/node-client",
-  "author": {
-    "name": "Thiago de Arruda",
-    "email": "tpadilha84@gmail.com"
-  },
+  "authors": [
+    {
+      "name": "Thiago de Arruda",
+      "email": "tpadilha84@gmail.com"
+    },
+    {
+      "name": "rhysd",
+      "email": "lin90162@yahoo.co.jp"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/neovim/node-client"
+    "url": "https://github.com/rhysd/promised-neovim-client"
   },
   "bugs": {
-    "url": "https://github.com/neovim/node-client/issues"
+    "url": "https://github.com/rhysd/promised-neovim-client/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/neovim/node-client/blob/master/LICENSE-MIT"
+      "url": "https://github.com/rhysd/promised-neovim-client/blob/master/LICENSE-MIT"
     }
   ],
   "main": "./index",
   "dependencies": {
+    "es6-promise": "^3.0.2",
     "lodash": "^3.9.3",
     "msgpack5rpc": "^1.0.1",
     "traverse": "^0.6.6"

--- a/package.json
+++ b/package.json
@@ -1,29 +1,23 @@
 {
-  "name": "promised-neovim-client",
-  "description": "Promised Neovim client library for modern JavaScript",
-  "version": "0.1.8",
+  "name": "neovim-client",
+  "description": "Neovim client library",
+  "version": "2.0.0",
   "homepage": "https://github.com/neovim/node-client",
-  "authors": [
-    {
-      "name": "Thiago de Arruda",
-      "email": "tpadilha84@gmail.com"
-    },
-    {
-      "name": "rhysd",
-      "email": "lin90162@yahoo.co.jp"
-    }
-  ],
+  "author": {
+    "name": "Thiago de Arruda",
+    "email": "tpadilha84@gmail.com"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/rhysd/promised-neovim-client"
+    "url": "https://github.com/neovim/node-client"
   },
   "bugs": {
-    "url": "https://github.com/rhysd/promised-neovim-client/issues"
+    "url": "https://github.com/neovim/node-client/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/rhysd/promised-neovim-client/blob/master/LICENSE-MIT"
+      "url": "https://github.com/neovim/node-client/blob/master/LICENSE-MIT"
     }
   ],
   "main": "./index",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var cp = require('child_process');
 var which = require('which');
-var attach = require('..');
+var attach = require('..').attach;
 
 for (var k in assert) global[k] = assert[k];
 
@@ -21,7 +21,7 @@ describe('Nvim', function() {
       cwd: __dirname
     });
 
-    attach(nvim.stdin, nvim.stdout, function(err, n) {
+    attach(nvim.stdin, nvim.stdout).then(function(n){
       nvim = n;
       nvim.on('request', function(method, args, resp) {
         requests.push({method: method, args: args});
@@ -40,26 +40,27 @@ describe('Nvim', function() {
   });
 
   it('can send requests and receive response', function(done) {
-    nvim.eval('{"k1": "v1", "k2": 2}', function(err, res) {
-      equal(err, null);
+    nvim.eval('{"k1": "v1", "k2": 2}').then(function(res) {
       deepEqual(res, {k1: 'v1', k2: 2});
       done();
+    }).catch(function(err){
+        throw err;
     });
   });
 
   it('can receive requests and send responses', function(done) {
-    nvim.eval('rpcrequest(1, "request", 1, 2, 3)', function(err, res) {
-      equal(err, null);
+    nvim.eval('rpcrequest(1, "request", 1, 2, 3)').then(function(res) {
       equal(res, 'received request(1,2,3)');
       deepEqual(requests, [{method: 'request', args: [1, 2, 3]}]);
       deepEqual(notifications, []);
       done();
+    }).catch(function(err){
+      throw err;
     });
   });
 
   it('can receive notifications', function(done) {
-    nvim.eval('rpcnotify(1, "notify", 1, 2, 3)', function(err, res) {
-      equal(err, null);
+    nvim.eval('rpcnotify(1, "notify", 1, 2, 3)').then(function(res) {
       equal(res, 1);
       deepEqual(requests, []);
       setImmediate(function() {
@@ -70,31 +71,34 @@ describe('Nvim', function() {
   });
 
   it('can deal with custom types', function(done) {
-    nvim.command('vsp', function(err, res) {
-      nvim.getWindows(function(err, windows) {
-        equal(windows.length, 2);
-        equal(windows[0] instanceof nvim.Window, true);
-        equal(windows[1] instanceof nvim.Window, true);
-        nvim.setCurrentWindow(windows[1], function(err, res) {
-          nvim.getCurrentWindow(function(err, win) {
-            equal(win.equals(windows[1]), true);
-            nvim.getCurrentBuffer(function(err, buf) {
-              equal(buf instanceof nvim.Buffer, true);
-              buf.getLineSlice(0, -1, true, true, function(err, lines) {
-                deepEqual(lines, ['']);
-                buf.setLineSlice(0, -1, true, true, ['line1', 'line2'], function(err) {
-                  buf.getLineSlice(0, -1, true, true, function(err, lines) {
-                    deepEqual(lines, ['line1', 'line2']);
-                    done();
-                  });
-                });
-              });
-            });
-          });
+    nvim.command('vsp').then(function(res){
+      return nvim.getWindows();
+    }).then(function(windows){
+      equal(windows.length, 2);
+      equal(windows[0] instanceof nvim.Window, true);
+      equal(windows[1] instanceof nvim.Window, true);
+      return nvim.setCurrentWindow(windows[1]).then(function(){
+        return nvim.getCurrentWindow();
+      }).then(function(win){
+        equal(win.equals(windows[1]), true);
+        return nvim.getCurrentBuffer();
+      }).then(function(buf){
+        equal(buf instanceof nvim.Buffer, true);
+        return buf.getLineSlice(0, -1, true, true).then(function(lines){
+          deepEqual(lines, ['']);
+          return buf.setLineSlice(0, -1, true, true, ['line1', 'line2']);
+        }).then(function(){
+          return buf.getLineSlice(0, -1, true, true);
+        }).then(function(lines){
+          deepEqual(lines, ['line1', 'line2']);
+          done();
         });
       });
+    }).catch(function(err){
+      console.log('foo');
+      console.log(err);
+      throw err;
     });
-
   });
 
   it('emits "disconnect" after quit', function(done) {


### PR DESCRIPTION
This commit has big changes to API.

```js
var cp = require('child_process');
var attach = require('promised-neovim-client').attach;

var nvim_proc = cp.spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {});
attach(nvim_proc.stdin, nvim_proc.stdout).then(function(nvim) {
  nvim.on('request', function(method, args, resp) {
    // handle msgpack-rpc request
  });

  nvim.on('notification', function(method, args) {
    // handle msgpack-rpc notification
  });

  nvim
    .command('vsp')
    .then(() => nvim.getWindows())
    .then(windows => {
      console.log(windows.length);  // 2
      console.log(windows[0] instanceof nvim.Window); // true
      console.log(windows[1] instanceof nvim.Window); // true
      return nvim.setCurrentWindow(windows[1])
        .then(() => nvim.getCurrentWindow())
        .then(win => {
          console.log(win.equals(windows[1]))  // true
          nvim.quit();
          nvim.on('disconnect', () => console.log("Nvim exited!"));
        });
    }).catch(err => console.log(err.message));

}).catch(err => console.log(err.message));
```

I changed the API to use `Promise` instead of callbacks.  I added new dependency `es6-promise` for ES6 Promise shim.
