### PR TITLE
Don't traverse into _session when decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ util.inherits(Nvim, EventEmitter);
 
 function decode(obj) {
   traverse(obj).forEach(function(item) {
-    if (Buffer.isBuffer(item)) {
+    if (item instanceof Session) {
+      this.update(item, true);
+    } else if (Buffer.isBuffer(item)) {
       try { this.update(item.toString('utf8')); } catch (e) {}
     }
   });


### PR DESCRIPTION
Fixes #8. 

`obj` holds some state for subsequent requests including the msgpack5 `BufferList` that should only contain `Buffer` objects. This function was replacing the contents of the buffer list with strings.