### PR TITLE
Export Generated Interfaces

### DIFF
--- a/generate-typescript-interfaces.js
+++ b/generate-typescript-interfaces.js
@@ -62,7 +62,7 @@ attach(proc.stdin, proc.stdout, function(err, nvim) {
   process.stdout.write('  function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void);\n\n');
 
   Object.keys(interfaces).forEach(function(key) {
-    process.stdout.write('  interface ' + key + ' {\n');
+    process.stdout.write('  export interface ' + key + ' {\n');
     Object.keys(interfaces[key].prototype).forEach(function(method) {
       method = interfaces[key].prototype[method];
       if (method.metadata) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module "neovim-client" {
   export default attach;
   function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void);
 
-  interface Nvim {
+  export interface Nvim {
     uiAttach(width: number, height: boolean, enable_rgb: (err: Error) => void, cb: (err: Error) => void): void;
     uiDetach(cb: (err: Error) => void): void;
     uiTryResize(width: number, height: (err: Error, res: Object) => void, cb: (err: Error, res: Object) => void): void;
@@ -43,7 +43,7 @@ declare module "neovim-client" {
     getColorMap(cb: (err: Error, res: {}) => void): void;
     getApiInfo(cb: (err: Error, res: Array<any>) => void): void;
   }
-  interface Buffer {
+  export interface Buffer {
     lineCount(cb: (err: Error, res: number) => void): void;
     getLine(index: number, cb: (err: Error, res: string) => void): void;
     setLine(index: number, line: string, cb: (err: Error) => void): void;
@@ -66,7 +66,7 @@ declare module "neovim-client" {
     addHighlight(src_id: number, hl_group: string, line: number, col_start: number, col_end: number, cb: (err: Error, res: number) => void): void;
     clearHighlight(src_id: number, line_start: number, line_end: number, cb: (err: Error) => void): void;
   }
-  interface Window {
+  export interface Window {
     getBuffer(cb: (err: Error, res: Buffer) => void): void;
     getCursor(cb: (err: Error, res: Array<number>) => void): void;
     setCursor(pos: Array<number>, cb: (err: Error) => void): void;
@@ -83,7 +83,7 @@ declare module "neovim-client" {
     getTabpage(cb: (err: Error, res: Tabpage) => void): void;
     isValid(cb: (err: Error, res: boolean) => void): void;
   }
-  interface Tabpage {
+  export interface Tabpage {
     getWindows(cb: (err: Error, res: Array<Window>) => void): void;
     getVar(name: string, cb: (err: Error, res: Object) => void): void;
     setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;


### PR DESCRIPTION
This is convenient e.g. if you're writing a plugin with the [node-host](https://github.com/neovim/node-host) and want to have types for the client passed to your commands, functions, etc.