### PR TITLE
Export attach() also as a default

### DIFF
--- a/generate-typescript-interfaces.js
+++ b/generate-typescript-interfaces.js
@@ -58,8 +58,7 @@ attach(proc.stdin, proc.stdout, function(err, nvim) {
 
   // use a similar reference path to other definitely typed declarations
   process.stdout.write('declare module "neovim-client" {\n');
-  process.stdout.write('  export default attach;\n');
-  process.stdout.write('  function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;\n\n');
+  process.stdout.write('  export default function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;\n\n');
 
   Object.keys(interfaces).forEach(function(key) {
     process.stdout.write('  export interface ' + key + ' {\n');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 declare module "neovim-client" {
-  export default attach;
-  function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;
+  export default function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;
 
   export interface Nvim {
     uiAttach(width: number, height: number, enable_rgb: boolean, cb: (err: Error) => void): void;

--- a/index.js
+++ b/index.js
@@ -197,3 +197,6 @@ module.exports = function attach(writer, reader, cb) {
     });
   });
 };
+
+// 'default' export for ES2015 or TypeScript environment.
+module.exports.default = module.exports;


### PR DESCRIPTION
Previously, `attach()` was exported as _whole_ of the package.  However, `index.d.ts` says that it is exported as _default_ of package.  _whole_ and _default_ is not the same thing in ES2015 and TypeScript, they are always confusing:

```javascript
// Whole import
import * as attach from 'neovim-client';

// Default import
import attach from 'neovim-client';
```

In general, people prefers default export because it's much more generic.  So I exported `attach()` also as a 'default' of this package.