### PR TITLE
Fix broken TypeScript type definition and introduce test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test:
 		else \
 		./node_modules/.bin/mocha $(TESTS); \
 		fi
+	@echo 'Check index.d.ts type definition.'
 	@./node_modules/.bin/tsc --target es5 --module commonjs --noImplicitAny --noEmit test/typescript-test.ts
 
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test:
 		else \
 		./node_modules/.bin/mocha $(TESTS); \
 		fi
+	@./node_modules/.bin/tsc --target es5 --module commonjs --noImplicitAny --noEmit test/typescript-test.ts
 
 
 watch:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,93 +1,96 @@
-declare module "neovim-client" {
-  export default function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;
+export default function attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream, cb: (err: Error, nvim: Nvim) => void): void;
 
-  export interface Nvim {
-    uiAttach(width: number, height: number, enable_rgb: boolean, cb: (err: Error) => void): void;
-    uiDetach(cb: (err: Error) => void): void;
-    uiTryResize(width: number, height: number, cb: (err: Error, res: Object) => void): void;
-    command(str: string, cb: (err: Error) => void): void;
-    feedkeys(keys: string, mode: string, escape_csi: boolean, cb: (err: Error) => void): void;
-    input(keys: string, cb: (err: Error, res: number) => void): void;
-    replaceTermcodes(str: string, from_part: boolean, do_lt: boolean, special: boolean, cb: (err: Error, res: string) => void): void;
-    commandOutput(str: string, cb: (err: Error, res: string) => void): void;
-    eval(str: string, cb: (err: Error, res: Object) => void): void;
-    callFunction(fname: string, args: Array<any>, cb: (err: Error, res: Object) => void): void;
-    strwidth(str: string, cb: (err: Error, res: number) => void): void;
-    listRuntimePaths(cb: (err: Error, res: Array<string>) => void): void;
-    changeDirectory(dir: string, cb: (err: Error) => void): void;
-    getCurrentLine(cb: (err: Error, res: string) => void): void;
-    setCurrentLine(line: string, cb: (err: Error) => void): void;
-    delCurrentLine(cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    delVar(name: string, cb: (err: Error, res: Object) => void): void;
-    getVvar(name: string, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    outWrite(str: string, cb: (err: Error) => void): void;
-    errWrite(str: string, cb: (err: Error) => void): void;
-    reportError(str: string, cb: (err: Error) => void): void;
-    getBuffers(cb: (err: Error, res: Array<Buffer>) => void): void;
-    getCurrentBuffer(cb: (err: Error, res: Buffer) => void): void;
-    setCurrentBuffer(buffer: Buffer, cb: (err: Error) => void): void;
-    getWindows(cb: (err: Error, res: Array<Window>) => void): void;
-    getCurrentWindow(cb: (err: Error, res: Window) => void): void;
-    setCurrentWindow(window: Window, cb: (err: Error) => void): void;
-    getTabpages(cb: (err: Error, res: Array<Tabpage>) => void): void;
-    getCurrentTabpage(cb: (err: Error, res: Tabpage) => void): void;
-    setCurrentTabpage(tabpage: Tabpage, cb: (err: Error) => void): void;
-    subscribe(event: string, cb: (err: Error) => void): void;
-    unsubscribe(event: string, cb: (err: Error) => void): void;
-    nameToColor(name: string, cb: (err: Error, res: number) => void): void;
-    getColorMap(cb: (err: Error, res: {}) => void): void;
-    getApiInfo(cb: (err: Error, res: Array<any>) => void): void;
-  }
-  export interface Buffer {
-    lineCount(cb: (err: Error, res: number) => void): void;
-    getLine(index: number, cb: (err: Error, res: string) => void): void;
-    setLine(index: number, line: string, cb: (err: Error) => void): void;
-    delLine(index: number, cb: (err: Error) => void): void;
-    getLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, cb: (err: Error, res: Array<string>) => void): void;
-    getLines(start: number, end: number, strict_indexing: boolean, cb: (err: Error, res: Array<string>) => void): void;
-    setLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, replacement: Array<string>, cb: (err: Error) => void): void;
-    setLines(start: number, end: number, strict_indexing: boolean, replacement: Array<string>, cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    delVar(name: string, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    getNumber(cb: (err: Error, res: number) => void): void;
-    getName(cb: (err: Error, res: string) => void): void;
-    setName(name: string, cb: (err: Error) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-    insert(lnum: number, lines: Array<string>, cb: (err: Error) => void): void;
-    getMark(name: string, cb: (err: Error, res: Array<number>) => void): void;
-    addHighlight(src_id: number, hl_group: string, line: number, col_start: number, col_end: number, cb: (err: Error, res: number) => void): void;
-    clearHighlight(src_id: number, line_start: number, line_end: number, cb: (err: Error) => void): void;
-  }
-  export interface Window {
-    getBuffer(cb: (err: Error, res: Buffer) => void): void;
-    getCursor(cb: (err: Error, res: Array<number>) => void): void;
-    setCursor(pos: Array<number>, cb: (err: Error) => void): void;
-    getHeight(cb: (err: Error, res: number) => void): void;
-    setHeight(height: number, cb: (err: Error) => void): void;
-    getWidth(cb: (err: Error, res: number) => void): void;
-    setWidth(width: number, cb: (err: Error) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    delVar(name: string, cb: (err: Error, res: Object) => void): void;
-    getOption(name: string, cb: (err: Error, res: Object) => void): void;
-    setOption(name: string, value: Object, cb: (err: Error) => void): void;
-    getPosition(cb: (err: Error, res: Array<number>) => void): void;
-    getTabpage(cb: (err: Error, res: Tabpage) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-  }
-  export interface Tabpage {
-    getWindows(cb: (err: Error, res: Array<Window>) => void): void;
-    getVar(name: string, cb: (err: Error, res: Object) => void): void;
-    setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
-    delVar(name: string, cb: (err: Error, res: Object) => void): void;
-    getWindow(cb: (err: Error, res: Window) => void): void;
-    isValid(cb: (err: Error, res: boolean) => void): void;
-  }
+export interface Nvim extends NodeJS.EventEmitter {
+  quit(): void;
+  uiAttach(width: number, height: number, enable_rgb: boolean, cb: (err: Error) => void): void;
+  uiDetach(cb: (err: Error) => void): void;
+  uiTryResize(width: number, height: number, cb: (err: Error, res: Object) => void): void;
+  command(str: string, cb: (err: Error) => void): void;
+  feedkeys(keys: string, mode: string, escape_csi: boolean, cb: (err: Error) => void): void;
+  input(keys: string, cb: (err: Error, res: number) => void): void;
+  replaceTermcodes(str: string, from_part: boolean, do_lt: boolean, special: boolean, cb: (err: Error, res: string) => void): void;
+  commandOutput(str: string, cb: (err: Error, res: string) => void): void;
+  eval(str: string, cb: (err: Error, res: Object) => void): void;
+  callFunction(fname: string, args: Array<any>, cb: (err: Error, res: Object) => void): void;
+  strwidth(str: string, cb: (err: Error, res: number) => void): void;
+  listRuntimePaths(cb: (err: Error, res: Array<string>) => void): void;
+  changeDirectory(dir: string, cb: (err: Error) => void): void;
+  getCurrentLine(cb: (err: Error, res: string) => void): void;
+  setCurrentLine(line: string, cb: (err: Error) => void): void;
+  delCurrentLine(cb: (err: Error) => void): void;
+  getVar(name: string, cb: (err: Error, res: Object) => void): void;
+  setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
+  delVar(name: string, cb: (err: Error, res: Object) => void): void;
+  getVvar(name: string, cb: (err: Error, res: Object) => void): void;
+  getOption(name: string, cb: (err: Error, res: Object) => void): void;
+  setOption(name: string, value: Object, cb: (err: Error) => void): void;
+  outWrite(str: string, cb: (err: Error) => void): void;
+  errWrite(str: string, cb: (err: Error) => void): void;
+  reportError(str: string, cb: (err: Error) => void): void;
+  getBuffers(cb: (err: Error, res: Array<Buffer>) => void): void;
+  getCurrentBuffer(cb: (err: Error, res: Buffer) => void): void;
+  setCurrentBuffer(buffer: Buffer, cb: (err: Error) => void): void;
+  getWindows(cb: (err: Error, res: Array<Window>) => void): void;
+  getCurrentWindow(cb: (err: Error, res: Window) => void): void;
+  setCurrentWindow(window: Window, cb: (err: Error) => void): void;
+  getTabpages(cb: (err: Error, res: Array<Tabpage>) => void): void;
+  getCurrentTabpage(cb: (err: Error, res: Tabpage) => void): void;
+  setCurrentTabpage(tabpage: Tabpage, cb: (err: Error) => void): void;
+  subscribe(event: string, cb: (err: Error) => void): void;
+  unsubscribe(event: string, cb: (err: Error) => void): void;
+  nameToColor(name: string, cb: (err: Error, res: number) => void): void;
+  getColorMap(cb: (err: Error, res: {}) => void): void;
+  getApiInfo(cb: (err: Error, res: Array<any>) => void): void;
+  equals(rhs: Nvim): boolean;
+}
+export interface Buffer {
+  lineCount(cb: (err: Error, res: number) => void): void;
+  getLine(index: number, cb: (err: Error, res: string) => void): void;
+  setLine(index: number, line: string, cb: (err: Error) => void): void;
+  delLine(index: number, cb: (err: Error) => void): void;
+  getLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, cb: (err: Error, res: Array<string>) => void): void;
+  getLines(start: number, end: number, strict_indexing: boolean, cb: (err: Error, res: Array<string>) => void): void;
+  setLineSlice(start: number, end: number, include_start: boolean, include_end: boolean, replacement: Array<string>, cb: (err: Error) => void): void;
+  setLines(start: number, end: number, strict_indexing: boolean, replacement: Array<string>, cb: (err: Error) => void): void;
+  getVar(name: string, cb: (err: Error, res: Object) => void): void;
+  setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
+  delVar(name: string, cb: (err: Error, res: Object) => void): void;
+  getOption(name: string, cb: (err: Error, res: Object) => void): void;
+  setOption(name: string, value: Object, cb: (err: Error) => void): void;
+  getNumber(cb: (err: Error, res: number) => void): void;
+  getName(cb: (err: Error, res: string) => void): void;
+  setName(name: string, cb: (err: Error) => void): void;
+  isValid(cb: (err: Error, res: boolean) => void): void;
+  insert(lnum: number, lines: Array<string>, cb: (err: Error) => void): void;
+  getMark(name: string, cb: (err: Error, res: Array<number>) => void): void;
+  addHighlight(src_id: number, hl_group: string, line: number, col_start: number, col_end: number, cb: (err: Error, res: number) => void): void;
+  clearHighlight(src_id: number, line_start: number, line_end: number, cb: (err: Error) => void): void;
+  equals(rhs: Buffer): boolean;
+}
+export interface Window {
+  getBuffer(cb: (err: Error, res: Buffer) => void): void;
+  getCursor(cb: (err: Error, res: Array<number>) => void): void;
+  setCursor(pos: Array<number>, cb: (err: Error) => void): void;
+  getHeight(cb: (err: Error, res: number) => void): void;
+  setHeight(height: number, cb: (err: Error) => void): void;
+  getWidth(cb: (err: Error, res: number) => void): void;
+  setWidth(width: number, cb: (err: Error) => void): void;
+  getVar(name: string, cb: (err: Error, res: Object) => void): void;
+  setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
+  delVar(name: string, cb: (err: Error, res: Object) => void): void;
+  getOption(name: string, cb: (err: Error, res: Object) => void): void;
+  setOption(name: string, value: Object, cb: (err: Error) => void): void;
+  getPosition(cb: (err: Error, res: Array<number>) => void): void;
+  getTabpage(cb: (err: Error, res: Tabpage) => void): void;
+  isValid(cb: (err: Error, res: boolean) => void): void;
+  equals(rhs: Window): boolean;
+}
+export interface Tabpage {
+  getWindows(cb: (err: Error, res: Array<Window>) => void): void;
+  getVar(name: string, cb: (err: Error, res: Object) => void): void;
+  setVar(name: string, value: Object, cb: (err: Error, res: Object) => void): void;
+  delVar(name: string, cb: (err: Error, res: Object) => void): void;
+  getWindow(cb: (err: Error, res: Window) => void): void;
+  isValid(cb: (err: Error, res: boolean) => void): void;
+  equals(rhs: Tabpage): boolean;
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "@types/node": "^6.0.34",
     "mocha": "^2.2.5",
     "nodemon": "^1.3.7",
+    "typescript": "^2.0.0",
     "which": "^1.1.1"
   },
   "scripts": {

--- a/test/typescript-test.ts
+++ b/test/typescript-test.ts
@@ -1,0 +1,37 @@
+import attach, {Window} from '..';
+import * as cp from 'child_process';
+
+const nvim_proc = cp.spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {});
+attach(nvim_proc.stdin, nvim_proc.stdout, (err, nvim) => {
+
+  if (err) {
+      console.error(err);
+      return;
+  }
+
+  nvim.on('request', (method: string, args: Object[], resp: Object) => {
+    // handle msgpack-rpc request
+  });
+
+  nvim.on('notification', (method: string, args: Object[]) => {
+    // handle msgpack-rpc notification
+  });
+
+  nvim.on('disconnect', () => {
+    console.log("Nvim exited!");
+  });
+
+  nvim.command('vsp', (err) => {
+    nvim.getWindows((err, windows) => {
+      console.log(windows.length);  // 2
+      console.log(windows[0] instanceof Window); // true
+      console.log(windows[1] instanceof Window); // true
+      nvim.setCurrentWindow(windows[1], (err) => {
+        nvim.getCurrentWindow((err, win) => {
+          console.log(win.equals(windows[1]))  // true
+          nvim.quit();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
I added a test for TypeScript type definitions and integrated it into CI.

And I fixed some broken points in `index.d.ts`

- `declare module` should not be used for type definitions resolved as npm package
- `Nvim` should inherit `EventEmitter`
- Add missing `equals()` methods