### PR TITLE
Use 'stable' and 'lts/*' to reduce maintain cost for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 before_install:
   - eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
+  - nvim --version
 
 node_js:
   - 'stable'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ before_install:
   - eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64"
 
 node_js:
-- '4.5'
-- '0.12'
+  - 'stable'
+  - 'lts/*'


### PR DESCRIPTION
Currently Node.js has two primary branches:

- stable: latest stable release
- LTS: long-term supported release

I think specifying them is better than specifying versions directly. We no longer need to take care about Node.js versions on Travis CI.