### PR TITLE
Updated typings for atomic call

### DIFF
--- a/src/api/Neovim.ts
+++ b/src/api/Neovim.ts
@@ -161,7 +161,7 @@ export class Neovim extends BaseApi {
   }
 
   /** Call Atomic calls */
-  callAtomic(calls: Array<any>): Promise<[Array<any>, boolean]> {
+  callAtomic(calls: Array<VimValue>): Promise<[Array<any>, boolean]> {
     return this.request(`${this.prefix}call_atomic`, [calls]);
   }
 

--- a/src/api/Neovim.ts
+++ b/src/api/Neovim.ts
@@ -161,7 +161,7 @@ export class Neovim extends BaseApi {
   }
 
   /** Call Atomic calls */
-  callAtomic(calls: Array<string>): Promise<[Array<any>, boolean]> {
+  callAtomic(calls: Array<any>): Promise<[Array<any>, boolean]> {
     return this.request(`${this.prefix}call_atomic`, [calls]);
   }
 


### PR DESCRIPTION
The typing for atomic call should be any[].