### PR TITLE
Fix TypeScript errors and test hang problem

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/__tests__/integration/autoload/provider/node.vim
+++ b/__tests__/integration/autoload/provider/node.vim
@@ -25,6 +25,11 @@ function! provider#node#Prog()
 endfunction
 
 function! provider#node#Require(host) abort
+  if s:err != ''
+    echoerr s:err
+    return
+  endif
+
   let args = ['node', provider#node#Prog()]
   let node_plugins = remote#host#PluginsForHost(a:host.name)
 
@@ -47,7 +52,7 @@ function! provider#node#Require(host) abort
   throw remote#host#LoadErrorForHost(a:host.orig_name, '$NVIM_NODE_LOG_FILE')
 endfunction
 
-function! provider#node#Call(method, args)
+function! provider#node#Call(method, args) abort
   if s:err != ''
     echoerr s:err
     return
@@ -72,7 +77,7 @@ let s:err = ''
 let s:prog = provider#node#Detect()
 
 if empty(s:prog)
-  let s:err = 'Cannot find the neovim-client node package. Try :CheckHealth'
+  let s:err = 'Cannot find the neovim-client node package. Try :CheckHealth. Did you forget `yarn link`?'
 endif
 
 " call remote#host#RegisterClone('legacy-node-provider', 'node')

--- a/__tests__/integration/rplugin/node/test/package.json
+++ b/__tests__/integration/rplugin/node/test/package.json
@@ -4,8 +4,7 @@
   "description": "A test fixture",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src --out-dir lib",
-    "test": "gulp test"
+    "build": "babel src --out-dir lib"
   },
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test-staged": "jest --bail --no-cache --findRelatedTests",
     "prep-integration-test": "(cd __tests__/integration/rplugin/node/test && npm install)",
     "precommit": "lint-staged",
-    "build": "tsc -p tsconfig.json || true",
+    "build": "tsc -p tsconfig.json",
     "watch": "tsc -p tsconfig.json --watch true"
   },
   "lint-staged": {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,26 +1,25 @@
 import * as winston from 'winston';
 
-let logger;
+let logger: winston.LoggerInstance;
 
-(<any>winston).level = process.env.NVIM_NODE_LOG_LEVEL || 'debug';
+const logLevel = process.env.NVIM_NODE_LOG_LEVEL || 'debug';
 
 if (process.env.NVIM_NODE_LOG_FILE) {
   logger = new winston.Logger({
     transports: [
       new winston.transports.File({
         filename: process.env.NVIM_NODE_LOG_FILE,
-        level: winston.level,
+        level: logLevel,
         json: false,
       }),
     ],
   });
 } else {
-  if (!process.env.ALLOW_CONSOLE) {
-    // Remove Console transport
-    winston.remove(winston.transports.Console);
+  logger = new winston.Logger({ level: logLevel });
+  if (process.env.ALLOW_CONSOLE) {
+    logger.add(winston.transports.Console);
   }
-  logger = winston;
 }
 
-export type ILogger = winston.Winston;
+export type ILogger = winston.LoggerInstance;
 export { logger };


### PR DESCRIPTION
I fixed following two points:

1. `tsc` errors. I used `new Logger` to make a logger instance also for console output in `utils/logger.ts`.
2. I noticed that test hung when `neovim-node-host` command was not found. I fixed it by adding check in `autoload/provider/node.vim`