### PR TITLE
AppVeyor for Windows CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,7 +25,7 @@ build: off
 test_script:
   - yarn
   - yarn link
-  - npm install -g .
+  - npm install -g . # provider#node#Detect() checks bin/cli.js directly. So symlink does not work (Issue #50)
   - yarn run prep-integration-test
   - yarn test -- --coverage
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,7 @@ build: off
 test_script:
   - yarn
   - yarn link
+  - npm install -g .
   - yarn run prep-integration-test
   - yarn test -- --coverage
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,14 @@
 version: '{build}'
 clone_depth: 10
 environment:
-  NVIM_NODE_LOG_LEVEL: debug
+  matrix:
+    - NODE_VERSION: ""
+      NVIM_NODE_LOG_LEVEL: debug
+    - NODE_VERSION: "8"
+      NVIM_NODE_LOG_LEVEL: debug
 
 install:
-  - ps: Install-Product node 8
+  - ps: Install-Product node $Env:NODE_VERSION
   - node --version
   - npm --version
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,40 @@
+version: '{build}'
+clone_depth: 10
+environment:
+  NVIM_NODE_LOG_LEVEL: debug
+
+install:
+  - ps: Install-Product node 8
+  - node --version
+  - npm --version
+  - ps: |
+      $zip = $Env:APPVEYOR_BUILD_FOLDER + '\nvim-win64.zip'
+      $nvim = $Env:APPVEYOR_BUILD_FOLDER + '\nvim-win64\'
+      $url = 'https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip'
+      (New-Object Net.WebClient).DownloadFile($url, $zip)
+      [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
+      [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $nvim)
+      $Env:PATH = $Env:PATH + ';' + $nvim + '\Neovim\bin\'
+  - echo %PATH%
+  - nvim --version
+  - npm install -g yarn
+  - yarn global add codecov
+
+build: off
+
+test_script:
+  - yarn
+  - yarn link
+  - yarn run prep-integration-test
+  - yarn test -- --coverage
+
+after_test:
+  - codecov
+
+deploy: off
+
+notifications:
+  - provider: Email
+    on_build_status_changed: true
+    on_build_success: false
+    on_build_failure: false

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # neovim-client
 
-| CI (Linux, macOS)                       | Coverage                               | npm                             | Gitter                      |
-|-----------------------------------------|----------------------------------------|---------------------------------|-----------------------------|
-| [![Build Status Badge][]][Build Status] | [![Coverage Badge][]][Coverage Report] | [![npm version][]][npm package] | [![Gitter Badge][]][Gitter] |
+| CI (Linux, macOS) | CI (Windows) | Coverage | npm | Gitter |
+|-------------------|--------------|----------|-----|--------|
+| [![Build Status Badge][]][Build Status] | [![Windows Build Status Badge][]][Windows Build Status] | [![Coverage Badge][]][Coverage Report] | [![npm version][]][npm package] | [![Gitter Badge][]][Gitter] |
 
 Currently tested for node >= 8
 
@@ -144,6 +144,8 @@ The tests and `scripts` can be consulted for more examples.
 
 [Build Status Badge]: https://travis-ci.org/neovim/node-client.svg?branch=master
 [Build Status]: https://travis-ci.org/neovim/node-client
+[Windows Build Status Badge]: https://ci.appveyor.com/api/projects/status/r989vwm83m7qc67m?svg=true
+[Windows Build Status]: https://ci.appveyor.com/project/rhysd/node-client
 [Coverage Badge]: https://codecov.io/gh/neovim/node-client/branch/master/graph/badge.svg
 [Coverage Report]: https://codecov.io/gh/neovim/node-client
 [npm version]: https://img.shields.io/npm/v/neovim.svg

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prepublishOnly": "npm run build",
     "test": "npm run build && jest --runInBand",
     "test-staged": "jest --bail --no-cache --findRelatedTests",
-    "prep-integration-test": "(cd __tests__/integration/rplugin/node/test && npm install)",
+    "prep-integration-test": "cd __tests__/integration/rplugin/node/test && npm install",
     "precommit": "lint-staged",
     "build": "tsc --pretty -p tsconfig.json",
     "watch": "tsc --pretty -p tsconfig.json --watch true"

--- a/src/api/Neovim.test.ts
+++ b/src/api/Neovim.test.ts
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import * as cp from 'child_process';
+import * as path from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as which from 'which';
 import { attach } from '../attach';
@@ -65,8 +66,7 @@ describe('Neovim API', () => {
 
     it('can change current working directory', async () => {
       const initial = await nvim.call('getcwd', []);
-      const parts = initial.split('/');
-      const newCwd = parts.slice(0, parts.length - 1).join('/');
+      const newCwd = path.dirname(initial);
 
       nvim.dir = newCwd;
       expect(await nvim.call('getcwd', [])).toBe(newCwd);


### PR DESCRIPTION
 I tried to setup AppVeyor. I wrote an AppVeyor config and a script to download nightly Neovim package. Now tests look to be run correctly.

But I have seen some test failures for node-host.

~~Since I'm not an node-host user, I could not fix the failures. Can anyone help me?~~

It seems that Travis CI is also failing. I think this is a problem of Neovim nightly and node-host. So I think this PR is mergable. @billyvg, what do you think?

CC: @janlazo

Fixes #47 
