### PR TITLE
Fixed Plugin TypeScript annotations, to keep the TypeScript compiler …

### DIFF
--- a/src/plugin/plugin.test.ts
+++ b/src/plugin/plugin.test.ts
@@ -14,6 +14,16 @@ describe('Plugin class decorator', () => {
     expect(NewClass[NVIM_PLUGIN]).toBe(true);
   });
 
+  it('decorates class when using TypeScript decorators', () => {
+	  @Plugin({})
+	  class MyClass {
+		  constructor(nvim) {
+		  }
+	  }
+
+	  expect(MyClass[NVIM_PLUGIN]).toBe(true);
+  });
+
   it('decorates class with dev mode option', () => {
     class MyClass {}
 

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -35,7 +35,7 @@ function wrapper(
 }
 
 // Can decorate a class with options object
-export function plugin(outter: any) {
+export function plugin<T extends { new(nvim: Neovim): {}}>(outter: any): (constructor: T) => T {
   /**
     * Decorator should support
     *
@@ -55,7 +55,7 @@ export function plugin(outter: any) {
     *
     * Plugin(TestPlugin)
     */
-  return typeof outter !== 'function'
-    ? (cls: any) => wrapper(cls, outter)
-    : wrapper(outter);
+	return <any>(typeof outter !== 'function'
+	? (cls: T) => wrapper(<any>cls, outter)
+    : wrapper(outter));
 }

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -35,7 +35,7 @@ function wrapper(
 }
 
 // Can decorate a class with options object
-export function plugin<T extends { new(nvim: Neovim): {}}>(outter: any): (constructor: T) => T {
+export function plugin<T extends { new(nvim: Neovim): {}}>(outer: any): (constructor: T) => T {
   /**
     * Decorator should support
     *
@@ -55,7 +55,7 @@ export function plugin<T extends { new(nvim: Neovim): {}}>(outter: any): (constr
     *
     * Plugin(TestPlugin)
     */
-	return <any>(typeof outter !== 'function'
-	? (cls: T) => wrapper(<any>cls, outter)
-    : wrapper(outter));
+	return <any>(typeof outer !== 'function'
+	? (cls: T) => wrapper(<any>cls, outer)
+    : wrapper(outer));
 }


### PR DESCRIPTION
…from failing when using the Plugin decorator in TypeScript

When using the Neovim module from TypeScript, the TypeScript compiler fails when using the Plugin decorator because the signature is not what it expects from a decorator. The fix adds proper annotations to the function declaration. The return value has to be cast, as the circular types PluginWrapperInterface and PluginWrapperConstructor will trip out the compiler. Added a test case, but this currently passes even without the fix, as the tests are not type checked according to tsconfig.json (the type checking is what is failing).