### PR TITLE
chore(): move types to devdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,6 @@
   "main": "./lib/index",
   "typings": "./lib/index",
   "dependencies": {
-    "@types/lodash": "^4.14.66",
-    "@types/msgpack-lite": "^0.1.4",
-    "@types/traverse": "^0.6.29",
-    "@types/winston": "^2.3.3",
     "lodash": "^4.17.4",
     "msgpack-lite": "^0.1.26",
     "traverse": "^0.6.6",
@@ -48,8 +44,12 @@
   },
   "devDependencies": {
     "@types/jest": "^20.0.1",
+    "@types/lodash": "^4.14.108",
+    "@types/msgpack-lite": "^0.1.4",
     "@types/node": "^7.0.32",
+    "@types/traverse": "^0.6.29",
     "@types/which": "^1.0.28",
+    "@types/winston": "^2.3.3",
     "babel-core": "^6.25.0",
     "husky": "^0.13.4",
     "jest": "^22.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
   version "20.0.8"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.8.tgz#7f8c97f73d20d3bf5448fbe33661a342002b5954"
 
-"@types/lodash@^4.14.66":
+"@types/lodash@^4.14.108":
   version "4.14.108"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.108.tgz#02656af3add2e5b3174f830862c47421c00ef817"
 


### PR DESCRIPTION
Right now if a plugin installs `neovim`, node_modules gets all the type information, which is not always needed.

 Moved `@types` packages to depDeps to only include  hard dependencies during `npm install --production`.