### PR TITLE
Use logger.error for plugin error

### DIFF
--- a/src/host/factory.ts
+++ b/src/host/factory.ts
@@ -131,8 +131,6 @@ function createPlugin(
   nvim: Neovim,
   options: LoadPluginOptions = {}
 ): NvimPlugin | null {
-  const debug = createDebugFunction(filename);
-
   try {
     const sandbox = createSandbox(filename);
 
@@ -150,8 +148,9 @@ function createPlugin(
       return new NvimPlugin(filename, plugin, nvim);
     }
   } catch (err) {
-    debug(`Error loading child ChildPlugin ${filename}`);
-    debug(err);
+    let file = path.basename(filename);
+    logger.error(`[${file}] ${err.stack}`);
+    logger.error(`[${file}] Error loading child ChildPlugin ${filename}`);
   }
 
   // There may have been an error, but maybe not


### PR DESCRIPTION
The log level `info` and `debug` contains too much information, the log file could easily increased to 100k lines, this change would makes it easier for plugin author to find error in the log.
 
Winston tends to ignore more than one error at the same time, so I put the stack log first.