### PR TITLE
fix(): slow performance on decode large data

### DIFF
--- a/src/utils/buffered.ts
+++ b/src/utils/buffered.ts
@@ -1,0 +1,55 @@
+import { Transform } from 'stream';
+
+const MIN_SIZE = 8 * 1024;
+
+export default class Buffered extends Transform {
+  private chunks: Buffer[] | null;
+  private timer: number | null;
+  constructor() {
+    super({
+      readableHighWaterMark: 10 * 1024 * 1024,
+      writableHighWaterMark: 10 * 1024 * 1024,
+    } as any);
+    this.chunks = null;
+    this.timer = null
+  }
+
+  sendData() {
+    let { chunks } = this;
+    if (chunks) {
+      this.chunks = null;
+      let buf = Buffer.concat(chunks);
+      this.push(buf);
+    }
+  }
+
+  _transform(chunk: Buffer, encoding: any, callback: any) {
+    let { chunks, timer } = this;
+    if (timer) clearTimeout(timer)
+    if (chunk.length < MIN_SIZE) {
+      if (!chunks) return callback(null, chunk);
+      chunks.push(chunk);
+      this.sendData();
+      callback();
+      return;
+    }
+    if (!chunks) {
+      chunks = this.chunks = [chunk];
+    } else {
+      chunks.push(chunk);
+    }
+    this.timer = setTimeout(this.sendData.bind(this), 20);
+    callback();
+  }
+
+  _flush(callback: any) {
+    let { chunks } = this;
+    if (chunks) {
+      this.chunks = null;
+      let buf = Buffer.concat(chunks);
+      callback(null, buf);
+    } else {
+      callback();
+    }
+  }
+}

--- a/src/utils/transport.ts
+++ b/src/utils/transport.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events';
 
 import * as msgpack from 'msgpack-lite';
 
+import Buffered from './buffered';
 import { Metadata } from '../api/types';
 
 class Response {
@@ -81,7 +82,8 @@ class Transport extends EventEmitter {
 
   attach(writer: NodeJS.WritableStream, reader: NodeJS.ReadableStream) {
     this.encodeStream = this.encodeStream.pipe(writer);
-    reader.pipe(this.decodeStream);
+    let buffered = new Buffered();
+    reader.pipe(buffered).pipe(this.decodeStream);
     this.writer = writer;
     this.reader = reader;
   }


### PR DESCRIPTION
`msgpack-lite` and `msgpack5` could be quite slow when working with streams that emit small chunks (8kb) of data each time,  it could be solved by using a buffered stream in the middle.

Detail at https://github.com/chemzqm/stream-issue