### PR TITLE
fix(CI): Consider nvim_buf_(attach|detach) APIs

### DIFF
--- a/scripts/findMissingApi.js
+++ b/scripts/findMissingApi.js
@@ -7,6 +7,20 @@ const search = process.argv[2] || '';
 const findConstructor = name => Metadata.find(obj => name.includes(obj.prefix));
 
 const hasApiMethod = name => {
+  // these are ignored because they are implemented, but has a non-normalized name/case
+  if (
+    [
+      'nvim_feedkeys',
+      'nvim_strwidth',
+      'nvim_err_writeln',
+      'nvim_buf_line_count',
+      'nvim_buf_attach',
+      'nvim_buf_detach',
+    ].includes(name)
+  ) {
+    return true;
+  }
+
   let methodName = name;
   const isSetter = name.includes('_set_');
   const isGetter =
@@ -34,10 +48,6 @@ const hasApiMethod = name => {
   const titleMethodName = `${methodName[0].toUpperCase()}${methodName.slice(
     1
   )}`;
-
-  // these are ignored because they are implemented, but has a non-normalized name/case
-  if (['feedkeys', 'strwidth', 'errWriteln', 'lineCount'].includes(methodName))
-    return true;
 
   const Constructor =
     (mappedConstructor && mappedConstructor.constructor) || Neovim;


### PR DESCRIPTION
Currently CI is failing at checking missing APIs due to `nvim_buf_(attach|detach)`.

https://travis-ci.org/neovim/node-client/jobs/390613752

I fixed the issue. And I modified the check for non-normalized names to look `name` rather than `methodName` because multiple methods may have the same method name. Checking `name` directly is safer.

Of course I checked these APIs are implemented in a client: https://github.com/neovim/node-client/blob/master/src/api/Buffer.ts#L29-L42