### PR TITLE
fix(api): Export NeovimClient

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export { Neovim } from './Neovim';
+export { NeovimClient } from './client';
 export { Buffer } from './Buffer';
 export { Window } from './Window';
 export { Tabpage } from './Tabpage';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { attach } from './attach';
-export { Neovim, Buffer, Tabpage, Window } from './api/index';
+export { Neovim, NeovimClient, Buffer, Tabpage, Window } from './api/index';
 export { Plugin, Function, Autocmd, Command } from './plugin';
 export { NvimPlugin } from './host/NvimPlugin';


### PR DESCRIPTION
Fix that NeovimClient class is not exported.

There're some API that only exists on NeovimClient, so typescript would not compile if plugin want to use them.