### PR TITLE
feat(api): add id attribute to Buffer and Window

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "winston": "^2.3.1"
   },
   "devDependencies": {
-    "@types/jest": "^20.0.1",
+    "@types/jest": "^23.1.0",
     "@types/lodash": "^4.14.108",
     "@types/msgpack-lite": "^0.1.4",
     "@types/node": "^7.0.32",
@@ -102,17 +102,8 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
-    "testMatch": [
-      "**/__tests__/**/*.(j|t)s?(x)",
-      "**/?(*.)(spec|test).(t|j)s?(x)"
-    ],
-    "coverageDirectory": "./coverage/",
-    "testPathIgnorePatterns": [
-      "node_modules",
-      "lib",
-      "scripts",
-      "__tests__/integration/rplugin"
-    ]
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
+    "coverageDirectory": "./coverage/"
   },
   "keywords": [
     "neovim",

--- a/src/api/Base.ts
+++ b/src/api/Base.ts
@@ -29,7 +29,7 @@ export class BaseApi extends EventEmitter {
   protected _isReady: Promise<boolean>;
   protected prefix: string;
   public logger: ILogger;
-  public data: Buffer; // Node Buffer
+  public data: Buffer | Number; // Node Buffer
   protected client: any;
 
   constructor({
@@ -57,7 +57,7 @@ export class BaseApi extends EventEmitter {
 
   equals(other: BaseApi) {
     try {
-      return this.data.toString() === other.data.toString();
+      return String(this.data) === String(other.data);
     } catch (e) {
       return false;
     }

--- a/src/api/Buffer.test.ts
+++ b/src/api/Buffer.test.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as which from 'which';
 import { attach } from '../attach';
+import { NeovimClient } from '../api/client';
 
 try {
   which.sync('nvim');
@@ -17,7 +18,7 @@ try {
 
 describe('Buffer API', () => {
   let proc;
-  let nvim;
+  let nvim: NeovimClient;
 
   beforeAll(async done => {
     proc = cp.spawn(
@@ -44,6 +45,12 @@ describe('Buffer API', () => {
   it('gets the current buffer', async () => {
     const buffer = await nvim.buffer;
     expect(buffer).toBeInstanceOf(nvim.Buffer);
+  });
+
+  it('get bufnr by id', async () => {
+    const buffer = await nvim.buffer;
+    const bufnr = await nvim.call('bufnr', ['%']);
+    expect(buffer.id).toBe(bufnr);
   });
 
   describe('Normal API calls', () => {

--- a/src/api/Buffer.ts
+++ b/src/api/Buffer.ts
@@ -41,6 +41,13 @@ export class Buffer extends BaseApi {
    */
   [DETACH] = () => this.request(`${this.prefix}detach`, [this]);
 
+  /**
+   * Get the bufnr of Buffer
+   */
+  get id(): number {
+    return this.data as number;
+  }
+
   /** Total number of lines in buffer */
   get length(): Promise<number> {
     return this.request(`${this.prefix}line_count`, [this]);

--- a/src/api/Window.test.ts
+++ b/src/api/Window.test.ts
@@ -3,6 +3,7 @@ import * as cp from 'child_process';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as which from 'which';
 import { attach } from '../attach';
+import { NeovimClient } from '../api/client';
 
 try {
   which.sync('nvim');
@@ -17,7 +18,7 @@ try {
 
 describe('Window API', () => {
   let proc;
-  let nvim;
+  let nvim: NeovimClient;
 
   beforeAll(async done => {
     proc = cp.spawn(
@@ -45,6 +46,12 @@ describe('Window API', () => {
   it('gets the current Window', async () => {
     const win = await nvim.window;
     expect(win).toBeInstanceOf(nvim.Window);
+  });
+
+  it('get windowid by id', async () => {
+    const win = await nvim.window;
+    const winid = await nvim.call('win_getid');
+    expect(win.id).toBe(winid);
   });
 
   describe('Normal API calls', () => {

--- a/src/api/Window.ts
+++ b/src/api/Window.ts
@@ -9,6 +9,13 @@ export interface AsyncWindow extends Window, Promise<Window> {}
 export class Window extends BaseApi {
   public prefix: string = Metadata[ExtType.Window].prefix;
 
+  /**
+   * The windowid that not change within a Vim session
+   */
+  get id(): number {
+    return this.data as number;
+  }
+
   /** Get current buffer of window */
   get buffer(): AsyncBuffer {
     return createChainableApi.call(this, 'Buffer', Buffer, () =>


### PR DESCRIPTION
The `data` of Buffer and Window would always be the buffer number and the number of windowid. (decoded by messagepack-lite).

This PR makes plugin have associate data with buffer and window easier.

Also fix jest not working on latest node.