### PR TITLE
feat(api): listen once for same event & handler

### DIFF
--- a/src/api/Buffer.test.ts
+++ b/src/api/Buffer.test.ts
@@ -289,7 +289,16 @@ describe('Buffer event updates', () => {
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
-  it('can use `buffer.off` to unlisten', async () => {
+  it('only bind once for the same event and handler ', async () => {
+    const buffer = await nvim.buffer;
+    const mock = jest.fn();
+    buffer.listen('lines', mock);
+    buffer.listen('lines', mock);
+    await nvim.buffer.insert(['bar'], 1);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('can use `buffer.unlisten` to unlisten', async () => {
     const buffer = await nvim.buffer;
     const mock = jest.fn();
     buffer.listen('lines', mock);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -213,6 +213,7 @@ export class NeovimClient extends Neovim {
     }
 
     const cbs = bufferMap.get(eventName);
+    if (cbs.indexOf(cb) !== -1) return cb;
     cbs.push(cb);
     bufferMap.set(eventName, cbs);
     this.attachedBuffers.set(bufferKey, bufferMap);


### PR DESCRIPTION
The buffer notification works well, except that I have to attach same event listener to a specified buffer event in different autocmd callback.

This PR prevents same listener attached multiply times.