### PR TITLE
fix(api): reattach of buffer sometimes not working

### DIFF
--- a/src/api/Buffer.test.ts
+++ b/src/api/Buffer.test.ts
@@ -5,6 +5,14 @@ import * as which from 'which';
 import { attach } from '../attach';
 import { NeovimClient } from '../api/client';
 
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
 try {
   which.sync('nvim');
 } catch (e) {
@@ -287,6 +295,18 @@ describe('Buffer event updates', () => {
     unlisten();
     await nvim.buffer.insert(['bar'], 1);
     expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('can reattach for buffer events', async () => {
+    const buffer = await nvim.buffer;
+    let unlisten = buffer.listen('lines', jest.fn());
+    unlisten();
+    await wait(10);
+    const mock = jest.fn();
+    unlisten = buffer.listen('lines', mock);
+    await nvim.buffer.insert(['bar'], 1);
+    expect(mock).toHaveBeenCalledTimes(1);
+    unlisten();
   });
 
   it('only bind once for the same event and handler ', async () => {

--- a/src/api/Buffer.ts
+++ b/src/api/Buffer.ts
@@ -256,6 +256,7 @@ export class Buffer extends BaseApi {
   unlisten(eventName: string, cb: Function) {
     const shouldDetach = this.client.detachBuffer(this, eventName, cb);
     if (!shouldDetach) return;
+    this.isAttached = false;
     this[DETACH]();
   }
 }


### PR DESCRIPTION
Mark `isAttached` to false on detach.

Note that there is a wait in the test, since attach again without detach returned would take no effect. May be the detach should return a promise to help this case.