### PR TITLE
[RFC] debug: spawn child process with --inspect-brk

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-const Host = require('../lib/host').Host;
-const logger = require('../lib/utils/logger').logger;
+const { Host } = require('../lib/host');
+const { logger } = require('../lib/utils/logger');
+const { spawnSync } = require('child_process');
+const semver = require('semver');
 
 // node <current script> <rest of args>
 const [, , ...args] = process.argv;
@@ -11,6 +13,19 @@ if (args[0] === '--version') {
   // eslint-disable-next-line no-console
   console.log(pkg.version);
   process.exit(0);
+}
+
+if (
+  process.env.NVIM_NODE_HOST_DEBUG &&
+  semver.satisfies(process.version, '>=7.6.0 || >=6.12.0 <7.0.0') &&
+  process.execArgv.every(token => token !== '--inspect-brk')
+) {
+  const childHost = spawnSync(
+    process.execPath,
+    process.execArgv.concat(['--inspect-brk']).concat(process.argv.slice(1)),
+    { stdio: 'inherit' }
+  );
+  process.exit(childHost.status);
 }
 
 try {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/traverse": "^0.6.29",
     "@types/which": "^1.0.28",
     "@types/winston": "^2.3.3",
+    "axios": "^0.18.0",
     "babel-core": "^6.25.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
@@ -103,6 +104,7 @@
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
     "coverageDirectory": "./coverage/",
     "testURL": "http://localhost"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "msgpack-lite": "^0.1.26",
+    "semver": "^5.6.0",
     "traverse": "^0.6.6",
     "winston": "^2.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@types/jest@^20.0.1":
-  version "20.0.8"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-20.0.8.tgz#7f8c97f73d20d3bf5448fbe33661a342002b5954"
+"@types/jest@^23.1.0":
+  version "23.3.7"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.7.tgz#77f9a4332ccf8db680a31818ade3ee454c831a79"
 
 "@types/lodash@^4.14.108":
   version "4.14.108"
@@ -3765,6 +3765,10 @@ semver-diff@^2.0.0:
 "semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,13 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -917,15 +924,15 @@ date-fns@^1.27.2:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@=3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -1478,6 +1485,12 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+follow-redirects@^1.3.0:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Fix #46 

I included style changes because of the precommit check with husky.
Running node with `--inspect-brk` silences the following error whether I spawn a new host or not:

```
net.js:704
    throw new TypeError(
    ^

TypeError: Invalid data, chunk must be a string or buffer, not object
    at WriteStream.Socket.write (net.js:704:11)
    at Transport.parseMessage (/home/janlazo/repo/git/node-client/lib/utils/transport.js:105:31)
    at DecodeStream.Transport.decodeStream.on (/home/janlazo/repo/git/node-client/lib/utils/transport.js:37:18)
    at emitOne (events.js:116:13)
    at DecodeStream.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at DecodeStream.Readable.push (_stream_readable.js:208:10)
    at DecodeStream.Transform.push (_stream_transform.js:147:32)
    at DecodeBuffer.DecodeStream.decoder.push (/home/janlazo/repo/git/node-client/node_modules/msgpack-lite/lib/decode-stream.js:24:12)
```