### PR TITLE
make each test uses its own buffer

### DIFF
--- a/src/api/Buffer.test.ts
+++ b/src/api/Buffer.test.ts
@@ -28,6 +28,25 @@ describe('Buffer API', () => {
   let proc;
   let nvim: NeovimClient;
 
+  // utility to allow each test to be run in its 
+  // own buffer
+  function withBuffer(lines,test) { 
+    return async () => {
+        await nvim.command('new');
+
+        const buffer = await nvim.buffer;
+
+        if( lines ) {
+            await buffer;
+            await buffer.replace(lines,0);
+        }
+
+        await test(buffer);
+
+        await nvim.command('bd! ' + buffer.id);
+    }
+  }
+
   beforeAll(async done => {
     proc = cp.spawn(
       'nvim',
@@ -50,24 +69,20 @@ describe('Buffer API', () => {
 
   beforeEach(() => {});
 
-  it('gets the current buffer', async () => {
-    const buffer = await nvim.buffer;
-    expect(buffer).toBeInstanceOf(nvim.Buffer);
-  });
+  it('gets the current buffer', withBuffer(
+    [], async buffer => {
+        expect(buffer).toBeInstanceOf(nvim.Buffer);
+    }
+  ));
 
-  it('get bufnr by id', async () => {
-    const buffer = await nvim.buffer;
+  it('get bufnr by id', withBuffer( [], async buffer => {
     const bufnr = await nvim.call('bufnr', ['%']);
     expect(buffer.id).toBe(bufnr);
-  });
+  }));
 
   describe('Normal API calls', () => {
-    let buffer;
-    beforeEach(async () => {
-      buffer = await nvim.buffer;
-    });
 
-    it('gets changedtick of buffer', async () => {
+    it('gets changedtick of buffer', withBuffer([], async buffer => {
       const initial = await buffer.changedtick;
 
       // insert a line
@@ -77,68 +92,84 @@ describe('Buffer API', () => {
       // clear buffer
       buffer.remove(0, -1, false);
       expect(await buffer.changedtick).toBe(initial + 2);
-    });
+    }));
 
     it('gets the current buffer name', async () => {
-      const name = await buffer.name;
+      const name = await (await nvim.buffers )[0].name;
       expect(name).toMatch('test.js');
     });
 
-    it('is a valid buffer', async () => {
+    it('is a valid buffer', withBuffer([],async buffer => {
       expect(await buffer.valid).toBe(true);
+    }));
+
+    it('sets current buffer name to "foo.js"', withBuffer( [],
+        async buffer => {
+            buffer.name = 'foo.js';
+            expect(await buffer.name).toMatch('foo.js');
+            buffer.name = 'test2.js';
+            expect(await buffer.name).toMatch('test2.js');
+    }));
+
+    it('can replace first line of buffer with a string', withBuffer(
+        ['foo'], async buffer => {
+            buffer.replace('test', 0);
+            expect(await buffer.lines).toEqual(['test']);
+    }));
+
+    it('can insert lines at beginning of buffer', withBuffer( ['test'],
+        async buffer => {
+            await buffer.insert(['test', 'foo'], 0);
+            expect(await buffer.lines).toEqual(['test', 'foo', 'test']);
+        })
+    );
+
+    it('can replace buffer starting at line 1', withBuffer(
+        ['test','b','c','d'],
+        async buffer => {
+            buffer.replace(['bar', 'bar', 'bar'], 1);
+            expect(await buffer.lines).toEqual(['test', 'bar', 'bar', 'bar']);
+        }
+    ));
+
+    it('inserts line at index 2', withBuffer(
+        ['test','bar','bar', 'bar'],
+        async buffer => {
+            buffer.insert(['foo'], 2);
+            expect(await buffer.lines).toEqual(['test', 'bar', 'foo', 'bar', 'bar']);
+        }
+    ));
+
+    it('removes last 2 lines', withBuffer(
+        ['test','bar','foo','a','b'],
+        async buffer => {
+            buffer.remove(-3, -1);
+            expect(await buffer.lines).toEqual(['test', 'bar', 'foo']);
+        },
+    ));
+
+    it('append lines to end of buffer', withBuffer(
+        [ 'test', 'bar', 'foo' ],
+        async buffer => {
+            await buffer.append(['test', 'test']);
+
+            expect(await buffer.lines).toEqual([
+                'test',
+                'bar',
+                'foo',
+                'test',
+                'test',
+            ]);
     });
 
-    it('sets current buffer name to "foo.js"', async () => {
-      buffer.name = 'foo.js';
-      expect(await buffer.name).toMatch('foo.js');
-      buffer.name = 'test.js';
-      expect(await buffer.name).toMatch('test.js');
-    });
-
-    it('can replace first line of buffer with a string', async () => {
-      buffer.replace('test', 0);
-      expect(await buffer.lines).toEqual(['test']);
-    });
-
-    it('can insert lines at beginning of buffer', async () => {
-      buffer.insert(['test', 'foo'], 0);
-      expect(await buffer.lines).toEqual(['test', 'foo', 'test']);
-    });
-
-    it('can replace buffer starting at line 1', async () => {
-      buffer.replace(['bar', 'bar', 'bar'], 1);
-      expect(await buffer.lines).toEqual(['test', 'bar', 'bar', 'bar']);
-    });
-
-    it('inserts line at index 2', async () => {
-      buffer.insert(['foo'], 2);
-      expect(await buffer.lines).toEqual(['test', 'bar', 'foo', 'bar', 'bar']);
-    });
-
-    it('removes last 2 lines', async () => {
-      buffer.remove(-3, -1);
-      expect(await buffer.lines).toEqual(['test', 'bar', 'foo']);
-    });
-
-    it('append lines to end of buffer', async () => {
-      buffer.append(['test', 'test']);
-      expect(await buffer.lines).toEqual([
-        'test',
-        'bar',
-        'foo',
-        'test',
-        'test',
-      ]);
-    });
-
-    it('can clear the buffer', async () => {
+    it('can clear the buffer', withBuffer( [ 'foo' ], async buffer => {
       buffer.remove(0, -1);
       // One empty line
       expect(await buffer.length).toEqual(1);
       expect(await buffer.lines).toEqual(['']);
-    });
+    }));
 
-    it('changes buffer options', async () => {
+    it('changes buffer options', withBuffer( [], async buffer => {
       const initial = await buffer.getOption('copyindent');
       buffer.setOption('copyindent', true);
       expect(await buffer.getOption('copyindent')).toBe(true);
@@ -148,45 +179,49 @@ describe('Buffer API', () => {
       // Restore option
       buffer.setOption('copyindent', initial);
       expect(await buffer.getOption('copyindent')).toBe(initial);
-    });
+    }));
 
-    it('returns null if variable is not found', async () => {
-      const test = await buffer.getVar('test');
-      expect(test).toBe(null);
-    });
+    it('returns null if variable is not found', withBuffer( 
+        [], async buffer => {
+            const test = await buffer.getVar('test');
+            expect(test).toBe(null);
+    }));
 
-    it('can set a b: variable to an object', async () => {
-      buffer.setVar('test', { foo: 'testValue' });
+    it('can set and delete a b: variable to an object', withBuffer(
+        [], async buffer => {
+            buffer.setVar('test', { foo: 'testValue' });
 
-      expect(await buffer.getVar('test')).toEqual({ foo: 'testValue' });
+            expect(await buffer.getVar('test')).toEqual({ foo: 'testValue' });
 
-      expect(await nvim.eval('b:test')).toEqual({ foo: 'testValue' });
-    });
+            expect(await nvim.eval('b:test')).toEqual({ foo: 'testValue' });
+            buffer.deleteVar('test');
 
-    it('can delete a b: variable', async () => {
-      buffer.deleteVar('test');
+            expect(await nvim.eval('exists("b:test")')).toBe(0);
 
-      expect(await nvim.eval('exists("b:test")')).toBe(0);
-
-      expect(await buffer.getVar('test')).toBe(null);
-    });
+            expect(await buffer.getVar('test')).toBe(null);
+    }));
 
     it('can get list of commands', async () => {
       expect(await nvim.buffer.commands).toEqual({});
     });
 
+
     // TODO: How do we run integration tests for add/clear highlights? and get mark
   });
 
   describe('Chainable API calls', () => {
-    it('gets the current buffer name using api chaining', async done => {
-      expect(await nvim.buffer.name).toMatch('test.js');
 
-      nvim.buffer.name.then(name => {
-        expect(name).toMatch('test.js');
-        done();
-      });
-    });
+    it('gets the current buffer name using api chaining', withBuffer(
+        [],
+        async buffer => {
+            await( buffer.name = 'test3.js' );
+            expect(await buffer.name).toMatch('test3.js');
+
+            await buffer.name.then(name => {
+                expect(name).toMatch('test3.js');
+            });
+        }
+    ));
 
     it('can chain calls from Base class i.e. getOption', async () => {
       const initial = await nvim.buffer.getOption('copyindent');
@@ -200,62 +235,83 @@ describe('Buffer API', () => {
       expect(await nvim.buffer.getOption('copyindent')).toBe(initial);
     });
 
-    it('sets current buffer name to "bar.js" using api chaining', async () => {
-      nvim.buffer.name = 'bar.js';
-      expect(await nvim.buffer.name).toMatch('bar.js');
-      nvim.buffer.name = 'test.js';
-      expect(await nvim.buffer.name).toMatch('test.js');
+    it('sets current buffer name to "bar.js" using api chaining', 
+        withBuffer( [],
+            async buffer => {
+                await( buffer.name = 'bar.js' );
+                expect(await buffer.name).toMatch('bar.js');
+
+                await( buffer.name = 'test2.js' );
+                expect(await buffer.name).toMatch('test2.js');
+            }
+        )
+    );
+
+    it('can replace first line of nvim.buffer with a string', withBuffer( [],
+        async buffer => {
+            buffer.replace('test', 0);
+            expect(await buffer.lines).toEqual(['test']);
+    }));
+
+    it('can insert lines at beginning of buffer', withBuffer(
+        ['test'],
+        async buffer => {
+            buffer.insert(['test', 'foo'], 0);
+            expect(await buffer.lines).toEqual(['test', 'foo', 'test']);
+        },
+    ));
+
+    it('can replace nvim.buffer starting at line 1', withBuffer(
+        ['test','foo'],
+        async buffer => {
+            await buffer.replace(['bar', 'bar', 'bar'], 1);
+            expect(await buffer.lines).toEqual(['test', 'bar', 'bar', 'bar']);
+        }
+    ));
+    async () => {
+      const buffer = await newBuffer(['a','b','c','d','e']);
     });
 
-    it('can replace first line of nvim.buffer with a string', async () => {
-      nvim.buffer.replace('test', 0);
-      expect(await nvim.buffer.lines).toEqual(['test']);
-    });
+    it('inserts line at index 2', withBuffer( 
+        [ 'test', 'bar', 'bar', 'bar' ],
+        async buffer => {
+            await buffer.insert(['foo'], 2);
+            expect(await buffer.lines).toEqual([
+                'test',
+                'bar',
+                'foo',
+                'bar',
+                'bar',
+            ]);
+            }
+    ));
 
-    it('can insert lines at beginning of buffer', async () => {
-      nvim.buffer.insert(['test', 'foo'], 0);
-      expect(await nvim.buffer.lines).toEqual(['test', 'foo', 'test']);
-    });
+    it('removes last 2 lines', withBuffer( 
+        [ 'test', 'bar', 'foo', 'a', 'b' ],
+        async buffer => {
+            await buffer.remove(-3, -1);
+            expect(await buffer.lines).toEqual([ 'test', 'bar', 'foo' ]);
+        }
+    ));
 
-    it('can replace nvim.buffer starting at line 1', async () => {
-      nvim.buffer.replace(['bar', 'bar', 'bar'], 1);
-      expect(await nvim.buffer.lines).toEqual(['test', 'bar', 'bar', 'bar']);
-    });
-
-    it('inserts line at index 2', async () => {
-      nvim.buffer.insert(['foo'], 2);
-      expect(await nvim.buffer.lines).toEqual([
+    it('append lines to end of buffer', withBuffer(
+    [ 'test', 'bar', 'foo' ], async buffer => {
+      await buffer.append(['test', 'test']);
+      expect(await buffer.lines).toEqual([
         'test',
         'bar',
         'foo',
-        'bar',
-        'bar',
-      ]);
-    });
-
-    it('removes last 2 lines', async () => {
-      nvim.buffer.remove(-3, -1);
-      expect(await nvim.buffer.lines).toEqual(['test', 'bar', 'foo']);
-    });
-
-    it('append lines to end of buffer', async () => {
-      nvim.buffer.append(['test', 'test']);
-      expect(await nvim.buffer.lines).toEqual([
-        'test',
-        'bar',
-        'foo',
         'test',
         'test',
-      ]);
-    });
+        ]);
+    }));
 
-    it('can clear the buffer', async () => {
-      nvim.buffer.remove(0, -1);
+    it('can clear the buffer', withBuffer( ['foo'], async buffer => {
+      await buffer.remove(0, -1);
       // One empty line
-      expect(await nvim.buffer.length).toEqual(1);
-      expect(await nvim.buffer.lines).toEqual(['']);
-    });
-  });
+      expect(await buffer.length).toEqual(1);
+      expect(await buffer.lines).toEqual(['']);
+    }));
 });
 
 describe('Buffer event updates', () => {


### PR DESCRIPTION
The way tests were written, they were all using the same buffer.
And since the tests are all asynchronous, there was a good chance
that the input of one test would affect the result of another test.
To make things worse, each test was expecting the buffer to be in
the state the previous test would have left it, which does not
work well with `jest --watch`, or running one test as a standalone.

What I did was to add a wrapper, `withBuffer`, which creates a new
buffer before the test, makes it accessible to the test itself,
and then close it down once the test is done.

Was discovered when doing work for #96