### PR TITLE
CI: config: codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+  ci:
+    - appveyor
+    - travis
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  javascript:
+    enable_partials: yes
+
+comment: off


### PR DESCRIPTION
- Disable obnoxious comment.
- Allow range. Currently uses the same 70...100 range as neovim. Feel
  free to change it to something narrower; the main goal is to avoid
  failing PRs for sub-1% fluctuations.
- Fix the badge?