### PR TITLE
fix(buffer): fix attach events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neovim",
   "description": "Neovim client API and neovim remote plugin provider",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "homepage": "https://github.com/neovim/node-client",
   "authors": [
     {

--- a/src/api/Buffer.test.ts
+++ b/src/api/Buffer.test.ts
@@ -452,6 +452,18 @@ describe('Buffer event updates', () => {
     unlisten();
   });
 
+  it('should return attached state', async () => {
+    const buffer = await nvim.buffer;
+    const unlisten = buffer.listen('lines', jest.fn());
+    await wait(30);
+    let attached = buffer.isAttached;
+    expect(attached).toBe(true);
+    unlisten();
+    await wait(30);
+    attached = buffer.isAttached;
+    expect(attached).toBe(false);
+  });
+
   it('only bind once for the same event and handler ', async () => {
     const buffer = await nvim.buffer;
     const mock = jest.fn();

--- a/src/api/Buffer.ts
+++ b/src/api/Buffer.ts
@@ -24,7 +24,10 @@ export const ATTACH = Symbol('attachBuffer');
 
 export class Buffer extends BaseApi {
   public prefix: string = Metadata[ExtType.Buffer].prefix;
-  private isAttached: boolean = false;
+
+  public get isAttached(): boolean {
+    return this.client.isAttached(this);
+  }
 
   /**
    * Attach to buffer to listen to buffer events
@@ -33,8 +36,17 @@ export class Buffer extends BaseApi {
    *        `nvim_buf_lines_event`. Otherwise, the first notification will be
    *        a `nvim_buf_changedtick_event`
    */
-  [ATTACH] = (sendBuffer: boolean = false, options: {} = {}) =>
-    this.request(`${this.prefix}attach`, [this, sendBuffer, options]);
+  [ATTACH] = async (
+    sendBuffer: boolean = false,
+    options: {} = {}
+  ): Promise<boolean> => {
+    if (this.client.isAttached(this)) return true;
+    return await this.request(`${this.prefix}attach`, [
+      this,
+      sendBuffer,
+      options,
+    ]);
+  }
 
   /**
    * Detach from buffer to stop listening to buffer events
@@ -267,22 +279,21 @@ export class Buffer extends BaseApi {
   /**
    * Listens to buffer for events
    */
-  listen(eventName: string, cb: Function): Function {
+  async listen(eventName: string, cb: Function): Promise<Function|null> {
     if (!this.isAttached) {
-      this[ATTACH]();
-      this.isAttached = true;
+      let attached = await this[ATTACH]();
+      if (!attached) return null;
     }
-
     this.client.attachBuffer(this, eventName, cb);
     return () => {
       this.unlisten(eventName, cb);
     };
   }
 
-  unlisten(eventName: string, cb: Function) {
+  unlisten(eventName: string, cb: Function): void {
+    if (!this.isAttached) return;
     const shouldDetach = this.client.detachBuffer(this, eventName, cb);
     if (!shouldDetach) return;
-    this.isAttached = false;
     this[DETACH]();
   }
 }

--- a/src/api/Buffer.ts
+++ b/src/api/Buffer.ts
@@ -41,11 +41,7 @@ export class Buffer extends BaseApi {
     options: {} = {}
   ): Promise<boolean> => {
     if (this.client.isAttached(this)) return true;
-    return await this.request(`${this.prefix}attach`, [
-      this,
-      sendBuffer,
-      options,
-    ]);
+    return this.request(`${this.prefix}attach`, [this, sendBuffer, options]);
   }
 
   /**
@@ -279,11 +275,15 @@ export class Buffer extends BaseApi {
   /**
    * Listens to buffer for events
    */
-  async listen(eventName: string, cb: Function): Promise<Function|null> {
+  listen(eventName: string, cb: Function): Function {
     if (!this.isAttached) {
-      let attached = await this[ATTACH]();
-      if (!attached) return null;
+      this[ATTACH]().then(attached => {
+        if (!attached) {
+          this.unlisten(eventName, cb);
+        }
+      });
     }
+
     this.client.attachBuffer(this, eventName, cb);
     return () => {
       this.unlisten(eventName, cb);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -51,6 +51,11 @@ export class NeovimClient extends Neovim {
     });
   }
 
+  isAttached(buffer: Buffer): boolean {
+    const key = `${buffer.data}`;
+    return this.attachedBuffers.has(key);
+  }
+
   handleRequest(
     method: string,
     args: VimValue[],


### PR DESCRIPTION
PR originally by @chemzqm 

* Not use internal isAttached
* Add buffer.isAttached method
* Unbind listener if attach failed

Closes https://github.com/neovim/node-client/pull/93