### PR TITLE
feat(transport): bump up msgpack to latest official

### DIFF
--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -41,9 +41,9 @@
   "main": "./lib/index",
   "typings": "./lib/index",
   "dependencies": {
+    "@msgpack/msgpack": "^1.9.3",
     "lodash.defaults": "^4.2.0",
     "lodash.omit": "^4.5.0",
-    "msgpack-lite": "^0.1.26",
     "semver": "^7.1.1",
     "winston": "3.2.1"
   },
@@ -55,7 +55,6 @@
     "@types/jest": "^24.0.24",
     "@types/lodash.defaults": "^4.2.6",
     "@types/lodash.omit": "^4.5.6",
-    "@types/msgpack-lite": "^0.1.7",
     "@types/node": "10.17.x",
     "@types/which": "^1.3.2",
     "babel-jest": "^24.9.0",


### PR DESCRIPTION
This PR attempts to bump up msgpack from `msgpack-lite` to latest official (https://github.com/msgpack/msgpack-javascript).

msgpack-lite has not been updated for amount of time, meanwhile official bindings improved implementation, as well as some experimental perf improvement approach as well like wasm backend (https://github.com/msgpack/msgpack-javascript/blob/c969bc9045a2fc2e70cf3bddd7ccd2e71cff1a78/src/wasmFunctions.ts#L3, still experimental though)

to conform `@msgpack`'s api `transport`'s internal implementation has changed, but does not exposes any breaking changes so far.