### PR TITLE
feat(attach): allow custom logger for attach neovim proc

### DIFF
--- a/packages/neovim/src/api/Base.ts
+++ b/packages/neovim/src/api/Base.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from 'events';
 
 import { Transport } from '../utils/transport';
-import { logger as loggerModule } from '../utils/logger';
+import { Logger } from '../utils/logger';
 import { VimValue } from '../types/VimValue';
 
 export interface BaseConstructorOptions {
   transport?: Transport;
-  logger?: typeof loggerModule;
+  logger?: Logger;
   data?: Buffer;
   metadata?: any;
   client?: any;
@@ -31,7 +31,7 @@ export class BaseApi extends EventEmitter {
 
   protected prefix: string;
 
-  public logger: typeof loggerModule;
+  public logger: Logger;
 
   public data: Buffer | number;
 
@@ -49,7 +49,8 @@ export class BaseApi extends EventEmitter {
 
     this.setTransport(transport);
     this.data = data;
-    this.logger = logger || loggerModule;
+    // eslint-disable-next-line global-require
+    this.logger = logger || require('../utils/logger').logger;
     this.client = client;
 
     if (metadata) {

--- a/packages/neovim/src/attach/attach.ts
+++ b/packages/neovim/src/attach/attach.ts
@@ -2,13 +2,16 @@ import { createConnection } from 'net';
 import * as child from 'child_process';
 
 import { NeovimClient } from '../api/client';
-import { logger } from '../utils/logger';
+import { Logger } from '../utils/logger';
 
 export interface Attach {
   reader?: NodeJS.ReadableStream;
   writer?: NodeJS.WritableStream;
   proc?: NodeJS.Process | child.ChildProcess;
   socket?: string;
+  options?: {
+    logger?: Logger;
+  };
 }
 
 export function attach({
@@ -16,6 +19,7 @@ export function attach({
   writer: _writer,
   proc,
   socket,
+  options = {},
 }: Attach) {
   let writer;
   let reader;
@@ -33,7 +37,9 @@ export function attach({
   }
 
   if (writer && reader) {
-    const neovim = new NeovimClient({ logger });
+    // eslint-disable-next-line global-require
+    const loggerInstance = options.logger || require('../utils/logger').logger; // lazy load to winston only if needed
+    const neovim = new NeovimClient({ logger: loggerInstance });
     neovim.attach({
       writer,
       reader,

--- a/packages/neovim/src/utils/logger.ts
+++ b/packages/neovim/src/utils/logger.ts
@@ -2,12 +2,12 @@ import * as winston from 'winston';
 
 const level = process.env.NVIM_NODE_LOG_LEVEL || 'debug';
 
-const logger = winston.createLogger({
+const winstonLogger = winston.createLogger({
   level,
 });
 
 if (process.env.NVIM_NODE_LOG_FILE) {
-  logger.add(
+  winstonLogger.add(
     new winston.transports.File({
       filename: process.env.NVIM_NODE_LOG_FILE,
       level,
@@ -16,11 +16,12 @@ if (process.env.NVIM_NODE_LOG_FILE) {
 }
 
 if (process.env.ALLOW_CONSOLE) {
-  logger.add(
+  winstonLogger.add(
     new winston.transports.Console({
       format: winston.format.simple(),
     })
   );
 }
 
-export { logger };
+export type Logger = Pick<winston.Logger, 'info' | 'warn' | 'error' | 'debug'>;
+export const logger: Logger = winstonLogger;


### PR DESCRIPTION
relates to https://github.com/asvetliakov/vscode-neovim/issues/134

current logger only allows customizable behavior via env variable which works for majority of node.js entrypoint, but some cases (like vs code extension) overriding env variable is not very much feasible cases. `NeovimClient` ctor already accepts custom logger, but `attach` does not exposes it - this PR expands signature to `attach` to allow specify options for customizing points. 

Instead of expanding param to directly accepts `logger`, it accepts `options` object instead for possible future customizations.