### PR TITLE
Use macOS 10.14 on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
 - template: .azure-templates/yarn-job.yml  # Template reference
   parameters:
     name: 'macOS'
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
 
 - template: .azure-templates/yarn-job.yml  # Template reference
   parameters:


### PR DESCRIPTION
It seems that azure pipeline has stopped support for macOS 10.13. Now only 10.14 and 10.15 are available.

https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent