### PR TITLE
chore: Bump dev node version to 16.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-prettier": "^4.0.0",
-    "husky": "^7.0.2",
+    "husky": "^7.0.4",
     "lerna": "^4.0.0",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1",
@@ -47,7 +47,7 @@
     ]
   },
   "volta": {
-    "node": "10.18.0",
+    "node": "16.13.1",
     "yarn": "1.21.1"
   }
 }


### PR DESCRIPTION
v10 is no longer under LTS.