### PR TITLE
fix(nvim.js): $NVIM_LISTEN_ADDRESS is deprecated

### DIFF
--- a/packages/neovim/scripts/nvim.js
+++ b/packages/neovim/scripts/nvim.js
@@ -12,7 +12,11 @@ module.exports = (async function () {
   let proc;
   let socket;
 
-  if (process.env.NVIM_LISTEN_ADDRESS) {
+  if (process.env.NVIM) {
+    // Nvim 0.8+ https://github.com/neovim/neovim/pull/11009
+    socket = process.env.NVIM;
+  } else if (process.env.NVIM_LISTEN_ADDRESS) {
+    // Nvim 0.7 or older https://github.com/neovim/neovim/pull/11009
     socket = process.env.NVIM_LISTEN_ADDRESS;
   } else {
     proc = cp.spawn('nvim', ['-u', 'NONE', '--embed', '-n'], {


### PR DESCRIPTION
Use $NVIM with Nvim 0.8+.

https://github.com/neovim/neovim/pull/11009 (Nvim 0.8+) will change Nvim so that $NVIM_LISTEN_ADDRESS is _not_ passed to child processes.  After that, the correct way to detect a "host" or "parent" Nvim is to check for $NVIM env var: this means the current process is a child of Nvim.

The old $NVIM_LISTEN_ADDRESS env var had conflicting purposes as both a parameter ("the current process should _listen on_ this address") and a descriptor ("the current process is a _child of_ this address").