### PR TITLE
feat(api): Implement Extmark API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,6 +3747,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.134",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
@@ -6295,6 +6304,14 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -6341,6 +6358,17 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {
@@ -6445,6 +6473,15 @@
     "node_modules/neovim": {
       "resolved": "packages/neovim",
       "link": true
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7390,6 +7427,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "dependencies": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/snakecase-keys/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7815,8 +7885,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -8373,6 +8442,7 @@
       "dependencies": {
         "@msgpack/msgpack": "^2.7.1",
         "semver": "^7.3.5",
+        "snakecase-keys": "^5.4.4",
         "winston": "3.3.3"
       },
       "bin": {
@@ -11167,6 +11237,15 @@
         }
       }
     },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.134",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.134.tgz",
@@ -13099,6 +13178,14 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "requires": {
+        "tslib": "^2.0.3"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -13139,6 +13226,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "marked": {
       "version": "4.0.15",
@@ -13231,10 +13323,20 @@
         "jest-haste-map": "^27.2.0",
         "jest-resolve": "^27.2.0",
         "semver": "^7.3.5",
+        "snakecase-keys": "^5.4.4",
         "typedoc": "^0.22.4",
         "typescript": "^4.4.3",
         "which": "^2.0.2",
         "winston": "3.3.3"
+      }
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node-int64": {
@@ -13934,6 +14036,32 @@
         "is-fullwidth-code-point": "^3.0.0"
       }
     },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "snakecase-keys": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.4.4.tgz",
+      "integrity": "sha512-YTywJG93yxwHLgrYLZjlC75moVEX04LZM4FHfihjHe1FCXm+QaLOFfSf535aXOAd0ArVQMWUAe8ZPm4VtWyXaA==",
+      "requires": {
+        "map-obj": "^4.1.0",
+        "snake-case": "^3.0.4",
+        "type-fest": "^2.5.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14260,8 +14388,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@msgpack/msgpack": "^2.7.1",
     "semver": "^7.3.5",
+    "snakecase-keys": "^5.4.4",
     "winston": "3.3.3"
   },
   "devDependencies": {

--- a/packages/neovim/src/api/Base.ts
+++ b/packages/neovim/src/api/Base.ts
@@ -146,13 +146,13 @@ export class BaseApi extends EventEmitter {
   }
 
   /** Retrieves a scoped option depending on type of `this` */
-  getOption(name: string): Promise<VimValue> | void {
+  getOption(name: string): Promise<VimValue> {
     const args = this._getArgsByPrefix(name);
     return this.request(`${this.prefix}get_option`, args);
   }
 
   /** Set scoped option */
-  setOption(name: string, value: VimValue): Promise<void> | void {
+  setOption(name: string, value: VimValue): Promise<void> {
     const args = this._getArgsByPrefix(name, value);
     return this.request(`${this.prefix}set_option`, args);
   }

--- a/packages/neovim/src/api/Buffer.test.ts
+++ b/packages/neovim/src/api/Buffer.test.ts
@@ -575,4 +575,32 @@ describe('Buffer event updates', () => {
     unlisten1();
     await nvim.command('q!');
   });
+
+  it('creates, gets, and deletes extmarks', async () => {
+    await nvim.command('new!');
+
+    const buf = await nvim.buffer;
+    await buf.replace(['this is test'], 0);
+
+    const ns = await nvim.createNamespace('test');
+    expect(ns).toBeGreaterThan(0);
+
+    const id = await buf.setExtmark(ns, 0, 4);
+    expect(id).toBeGreaterThan(0);
+
+    const mark = await buf.getExtmarkById(ns, id);
+    expect(mark).toEqual([0, 4]);
+
+    const marks = await buf.getExtmarks(ns, [0, 0], [0, 8]);
+    expect(marks).toEqual([[id, 0, 4]]);
+
+    const deleted = await buf.deleteExtmark(ns, id);
+    expect(deleted).toEqual(true);
+
+    const markAfterDel = await buf.getExtmarkById(ns, id);
+    expect(markAfterDel).toEqual([]);
+
+    const marksAfterDel = await buf.getExtmarks(ns, [0, 0], [0, 8]);
+    expect(marksAfterDel).toEqual([]);
+  });
 });

--- a/packages/neovim/src/api/Buffer.test.ts
+++ b/packages/neovim/src/api/Buffer.test.ts
@@ -374,7 +374,7 @@ describe('Buffer API', () => {
     it(
       'removes last 2 lines',
       withBuffer(['test', 'bar', 'foo', 'a', 'b'], async () => {
-        await nvim.buffer.remove(-3, -1);
+        await nvim.buffer.remove(-3, -1, false);
         expect(await nvim.buffer.lines).toEqual(['test', 'bar', 'foo']);
       })
     );
@@ -396,7 +396,7 @@ describe('Buffer API', () => {
     it(
       'can clear the buffer',
       withBuffer(['foo'], async () => {
-        await nvim.buffer.remove(0, -1);
+        await nvim.buffer.remove(0, -1, false);
         // One empty line
         expect(await nvim.buffer.length).toEqual(1);
         expect(await nvim.buffer.lines).toEqual(['']);
@@ -488,7 +488,7 @@ describe('Buffer event updates', () => {
     const bufferName = await buffer.name;
     await buffer.insert(['test', 'foo'], 0);
 
-    const promise = new Promise(resolve => {
+    const promise = new Promise<void>(resolve => {
       const unlisten = buffer.listen(
         'lines',
         async (currentBuffer, tick, start, end, data) => {

--- a/packages/neovim/src/api/Buffer.ts
+++ b/packages/neovim/src/api/Buffer.ts
@@ -1,3 +1,4 @@
+import snakeCaseKeys = require('snakecase-keys');
 import { BaseApi } from './Base';
 import { ExtType, Metadata } from './types';
 
@@ -26,7 +27,47 @@ export interface BufferClearNamespace {
   lineEnd?: number;
 }
 
+export interface BufferGetExtmarksOptions {
+  limit?: number;
+  details?: boolean;
+}
+
+export interface BufferGetExtmarkOptions {
+  details?: boolean;
+}
+
+export interface BufferSetExtmarkOptions {
+  id?: number;
+  endRow?: number;
+  endCol?: number;
+  hlGroup?: string;
+  hlEol?: boolean;
+  virtText?: Array<[string, string | string[]]>;
+  virtTextPos?: 'eol' | 'overlay' | 'right_align';
+  virtTextWinCol?: number;
+  virtTextHide?: boolean;
+  hlMode?: 'replace' | 'combine' | 'blend';
+  virtLines?: Array<[string, string | string[]]>;
+  virtLinesAbove?: boolean;
+  virtLinesLeftcol?: boolean;
+  ephemeral?: boolean;
+  rightGravity?: boolean;
+  endRightGravity?: boolean;
+  priority?: number;
+  strict?: boolean;
+  signText?: string;
+  signHlGroup?: string;
+  numberHlGroup?: string;
+  lineHlGroup?: string;
+  cursorHlGroup?: string;
+  conceal?: string;
+  spell?: boolean;
+  uiWatched?: boolean;
+}
+
 export type VirtualTextChunk = [string, string];
+
+export type ExtmarkPosition = [number, number] | number;
 
 export const DETACH = Symbol('detachBuffer');
 export const ATTACH = Symbol('attachBuffer');
@@ -380,6 +421,202 @@ export class Buffer extends BaseApi {
     const shouldDetach = this.client.detachBuffer(this, eventName, cb);
     if (!shouldDetach) return;
     this[DETACH]();
+  }
+
+  /**
+   * Gets extmarks in "traversal order" from a charwise region defined by
+   * buffer positions (inclusive, 0-indexed).
+   *
+   * Region can be given as (row,col) tuples, or valid extmark ids (whose
+   * positions define the bounds). 0 and -1 are understood as (0,0) and (-1,-1)
+   *
+   * If `end` is less than `start`, traversal works backwards. (Useful with
+   * `limit`, to get the first marks prior to a given position.)
+   *
+   * @param {Number} namespaceId Namespace id from nvim_create_namespace()
+   * @param {ExtmarkPosition} start Start of range: a 0-indexed (row, col) or valid extmark id
+   *                                (whose position defines the bound).
+   * @param {ExtmarkPosition} end End of range (inclusive): a 0-indexed (row, col) or valid
+   *                              extmark id (whose position defines the bound).
+   * @param {BufferGetExtmarksOptions} options Optional parameters. Keys:
+   *                                           • limit: Maximum number of marks to return
+   *                                           • details: Whether to include the details dict
+   *
+   * @return List of [extmark_id, row, col] tuples in "traversal order".
+   */
+  getExtmarks(
+    namespaceId: number,
+    start: ExtmarkPosition,
+    end: ExtmarkPosition,
+    options: BufferGetExtmarksOptions = {}
+  ): Promise<Array<[number, number, number]>> {
+    return this.request(`${this.prefix}get_extmarks`, [
+      this,
+      namespaceId,
+      start,
+      end,
+      options,
+    ]);
+  }
+
+  /**
+   * Gets the position (0-indexed) of an extmark.
+   *
+   * @param {Number} ns_id Namespace id from |nvim_create_namespace()|
+   * @param {Number} id Extmark id
+   * @param {BufferGetExtmarkOptions} options Optional parameters. Keys:
+   *                                   • details: Whether to include the details dict
+   *
+   * @return 0-indexed (row, col) tuple or empty list () if extmark id was absent
+   */
+  getExtmarkById(
+    namespaceId: number,
+    id: number,
+    options: BufferGetExtmarkOptions = {}
+  ): Promise<[number, number] | []> {
+    return this.request(`${this.prefix}get_extmark_by_id`, [
+      this,
+      namespaceId,
+      id,
+      options,
+    ]);
+  }
+
+  /**
+   * Creates or updates an extmark.
+   *
+   * By default a new extmark is created when no id is passed in, but it is
+   * also possible to create a new mark by passing in a previously unused id or
+   * move an existing mark by passing in its id. The caller must then keep
+   * track of existing and unused ids itself. (Useful over RPC, to avoid
+   * waiting for the return value.)
+   *
+   * Using the optional arguments, it is possible to use this to highlight a
+   * range of text, and also to associate virtual text to the mark.
+   *
+   * @param {Number} ns_id Namespace id from nvim_create_namespace().
+   * @param {Number} line Line where to place the mark, 0-based.
+   * @param {Number} col Column where to place the mark, 0-based.
+   * @param {BufferSetExtmarkOptions} opts Optional parameters.
+   *                                       • id : id of the extmark to edit.
+   *                                       • end_row : ending line of the mark, 0-based inclusive.
+   *                                       • end_col : ending col of the mark, 0-based exclusive.
+   *                                       • hl_group : name of the highlight group used to highlight
+   *                                         this mark.
+   *                                       • hl_eol : when true, for a multiline highlight covering the
+   *                                         EOL of a line, continue the highlight for the rest of the
+   *                                         screen line (just like for diff and cursorline highlight).
+   *                                       • virt_text : virtual text to link to this mark. A list of
+   *                                         [text, highlight] tuples, each representing a text chunk
+   *                                         with specified highlight. `highlight` element can either
+   *                                         be a single highlight group, or an array of multiple
+   *                                         highlight groups that will be stacked (highest priority
+   *                                         last). A highlight group can be supplied either as a
+   *                                         string or as an integer, the latter which can be obtained
+   *                                         using nvim_get_hl_id_by_name().
+   *                                       • virt_text_pos : position of virtual text. Possible values:
+   *                                         • "eol": right after eol character (default)
+   *                                         • "overlay": display over the specified column, without
+   *                                           shifting the underlying text.
+   *                                         • "right_align": display right aligned in the window.
+   *
+   *                                       • virt_text_win_col : position the virtual text at a fixed
+   *                                         window column (starting from the first text column)
+   *                                       • virt_text_hide : hide the virtual text when the background
+   *                                         text is selected or hidden due to horizontal scroll
+   *                                         'nowrap'
+   *                                       • hl_mode : control how highlights are combined with the
+   *                                         highlights of the text. Currently only affects virt_text
+   *                                         highlights, but might affect `hl_group` in later versions.
+   *                                         • "replace": only show the virt_text color. This is the
+   *                                           default
+   *                                         • "combine": combine with background text color
+   *                                         • "blend": blend with background text color.
+   *
+   *                                       • virt_lines : virtual lines to add next to this mark This
+   *                                         should be an array over lines, where each line in turn is
+   *                                         an array over [text, highlight] tuples. In general, buffer
+   *                                         and window options do not affect the display of the text.
+   *                                         In particular 'wrap' and 'linebreak' options do not take
+   *                                         effect, so the number of extra screen lines will always
+   *                                         match the size of the array. However the 'tabstop' buffer
+   *                                         option is still used for hard tabs. By default lines are
+   *                                         placed below the buffer line containing the mark.
+   *                                       • virt_lines_above: place virtual lines above instead.
+   *                                       • virt_lines_leftcol: Place extmarks in the leftmost column
+   *                                         of the window, bypassing sign and number columns.
+   *                                       • ephemeral : for use with nvim_set_decoration_provider()
+   *                                         callbacks. The mark will only be used for the current
+   *                                         redraw cycle, and not be permantently stored in the
+   *                                         buffer.
+   *                                       • right_gravity : boolean that indicates the direction the
+   *                                         extmark will be shifted in when new text is inserted (true
+   *                                         for right, false for left). defaults to true.
+   *                                       • end_right_gravity : boolean that indicates the direction
+   *                                         the extmark end position (if it exists) will be shifted in
+   *                                         when new text is inserted (true for right, false for
+   *                                         left). Defaults to false.
+   *                                       • priority: a priority value for the highlight group or sign
+   *                                         attribute. For example treesitter highlighting uses a
+   *                                         value of 100.
+   *                                       • strict: boolean that indicates extmark should not be
+   *                                         placed if the line or column value is past the end of the
+   *                                         buffer or end of the line respectively. Defaults to true.
+   *                                       • sign_text: string of length 1-2 used to display in the
+   *                                         sign column. Note: ranges are unsupported and decorations
+   *                                         are only applied to start_row
+   *                                       • sign_hl_group: name of the highlight group used to
+   *                                         highlight the sign column text. Note: ranges are
+   *                                         unsupported and decorations are only applied to start_row
+   *                                       • number_hl_group: name of the highlight group used to
+   *                                         highlight the number column. Note: ranges are unsupported
+   *                                         and decorations are only applied to start_row
+   *                                       • line_hl_group: name of the highlight group used to
+   *                                         highlight the whole line. Note: ranges are unsupported and
+   *                                         decorations are only applied to start_row
+   *                                       • cursorline_hl_group: name of the highlight group used to
+   *                                         highlight the line when the cursor is on the same line as
+   *                                         the mark and 'cursorline' is enabled. Note: ranges are
+   *                                         unsupported and decorations are only applied to start_row
+   *                                       • conceal: string which should be either empty or a single
+   *                                         character. Enable concealing similar to conceal.
+   *                                         When a character is supplied it is used as cchar.
+   *                                         "hl_group" is used as highlight for the cchar if provided,
+   *                                         otherwise it defaults to Conceal.
+   *                                       • spell: boolean indicating that spell checking should be
+   *                                         performed within this extmark
+   *                                       • ui_watched: boolean that indicates the mark should be
+   *                                         drawn by a UI. When set, the UI will receive win_extmark
+   *                                         events. Note: the mark is positioned by virt_text
+   *                                         attributes. Can be used together with virt_text.
+   *
+   * @return Id of the created/updated extmark
+   */
+  setExtmark(
+    namespaceId: number,
+    line: number,
+    col: number,
+    options: BufferSetExtmarkOptions = {}
+  ): Promise<number> {
+    return this.request(`${this.prefix}set_extmark`, [
+      this,
+      namespaceId,
+      line,
+      col,
+      snakeCaseKeys(options),
+    ]);
+  }
+
+  /**
+   * Removes an extmark.
+   *
+   * @param {Number} ns_id Namespace id from |nvim_create_namespace()|
+   * @param {Number} id Extmark id
+   *
+   * @return true if the extmark was found, else false
+   */
+  deleteExtmark(namespaceId: number, id: number): Promise<boolean> {
+    return this.request(`${this.prefix}del_extmark`, [this, namespaceId, id]);
   }
 }
 

--- a/packages/neovim/src/api/Buffer.ts
+++ b/packages/neovim/src/api/Buffer.ts
@@ -1,4 +1,4 @@
-import snakeCaseKeys = require('snakecase-keys');
+import snakeCaseKeys from 'snakecase-keys';
 import { BaseApi } from './Base';
 import { ExtType, Metadata } from './types';
 

--- a/packages/neovim/src/api/Buffer.ts
+++ b/packages/neovim/src/api/Buffer.ts
@@ -37,31 +37,142 @@ export interface BufferGetExtmarkOptions {
 }
 
 export interface BufferSetExtmarkOptions {
+  /**
+   * id of the extmark to edit.
+   */
   id?: number;
+  /**
+   * ending line of the mark, 0-based inclusive.
+   */
   endRow?: number;
+  /**
+   * ending col of the mark, 0-based exclusive.
+   */
   endCol?: number;
+  /**
+   * name of the highlight group used to highlight this mark.
+   */
   hlGroup?: string;
+  /**
+   * when true, for a multiline highlight covering the EOL of a line, continue the highlight for
+   * the rest of the screen line (just like for diff and cursorline highlight).
+   */
   hlEol?: boolean;
+  /**
+   * virtual text to link to this mark. A list of [text, highlight] tuples, each representing a text
+   * chunk with specified highlight. `highlight` element can either be a single highlight group, or
+   * an array of multiple highlight groups that will be stacked (highest priority last). A highlight
+   * group can be supplied either as a string or as an integer, the latter which can be obtained
+   * using nvim_get_hl_id_by_name().
+   */
   virtText?: Array<[string, string | string[]]>;
+  /**
+   * position of virtual text. Possible values:
+   * • "eol": right after eol character (default)
+   * • "overlay": display over the specified column, without shifting the underlying text.
+   * • "right_align": display right aligned in the window.
+   */
   virtTextPos?: 'eol' | 'overlay' | 'right_align';
+  /**
+   * position the virtual text at a fixed window column (starting from the first text column).
+   */
   virtTextWinCol?: number;
+  /**
+   * hide the virtual text when the background text is selected or hidden due to horizontal scroll
+   * 'nowrap'.
+   */
   virtTextHide?: boolean;
+  /**
+   * control how highlights are combined with the highlights of the text. Currently only affects
+   * virt_text highlights, but might affect `hl_group` in later versions.
+   * • "replace": only show the virt_text color. This is the default
+   * • "combine": combine with background text color
+   * • "blend": blend with background text color
+   */
   hlMode?: 'replace' | 'combine' | 'blend';
+  /**
+   * virtual lines to add next to this mark This should be an array over lines, where each line in
+   * turn is an array over [text, highlight] tuples. In general, buffer and window options do not
+   * affect the display of the text. In particular 'wrap' and 'linebreak' options do not take
+   * effect, so the number of extra screen lines will always match the size of the array. However
+   * the 'tabstop' buffer option is still used for hard tabs. By default lines are placed below
+   * the buffer line containing the mark.
+   */
   virtLines?: Array<[string, string | string[]]>;
+  /**
+   * place virtual lines above instead.
+   */
   virtLinesAbove?: boolean;
+  /**
+   * Place extmarks in the leftmost column of the window, bypassing sign and number columns.
+   */
   virtLinesLeftcol?: boolean;
+  /**
+   * for use with nvim_set_decoration_provider(). callbacks. The mark will only be used for the
+   * current redraw cycle, and not be permantently stored in the buffer.
+   */
   ephemeral?: boolean;
+  /**
+   * boolean that indicates the direction the extmark will be shifted in when new text is inserted
+   * (true for right, false for left). defaults to true.
+   */
   rightGravity?: boolean;
+  /**
+   * boolean that indicates the direction the extmark end position (if it exists) will be shifted in
+   * when new text is inserted (true for right, false for left). Defaults to false.
+   */
   endRightGravity?: boolean;
+  /**
+   * boolean that indicates extmark should not be placed if the line or column value is past the end
+   * of the buffer or end of the line respectively. Defaults to true.
+   */
   priority?: number;
+  /**
+   * boolean that indicates extmark should not be placed if the line or column value is past the end
+   * of the buffer or end of the line respectively. Defaults to true.
+   */
   strict?: boolean;
+  /**
+   * string of length 1-2 used to display in the sign column. Note: ranges are unsupported and
+   * decorations are only applied to start_row.
+   */
   signText?: string;
+  /**
+   * name of the highlight group used to highlight the sign column text. Note: ranges are
+   * unsupported and decorations are only applied to start_row.
+   */
   signHlGroup?: string;
+  /**
+   * name of the highlight group used to highlight the number column. Note: ranges are unsupported
+   * and decorations are only applied to start_row.
+   */
   numberHlGroup?: string;
+  /**
+   * name of the highlight group used to highlight the whole line. Note: ranges are unsupported and
+   * decorations are only applied to start_row.
+   */
   lineHlGroup?: string;
+  /**
+   * name of the highlight group used to highlight the line when the cursor is on the same line as
+   * the mark and 'cursorline' is enabled. Note: ranges are unsupported and decorations are only
+   * applied to start_row.
+   */
   cursorHlGroup?: string;
+  /**
+   * string which should be either empty or a single character. Enable concealing similar to
+   * conceal. When a character is supplied it is used as cchar. "hl_group" is used as highlight for
+   * the cchar if provided, otherwise it defaults to Conceal.
+   */
   conceal?: string;
+  /**
+   * boolean indicating that spell checking should be performed within this extmark.
+   */
   spell?: boolean;
+  /**
+   * boolean that indicates the mark should be drawn by a UI. When set, the UI will receive
+   * win_extmark events. Note: the mark is positioned by virt_text attributes. Can be used together
+   * with virt_text.
+   */
   uiWatched?: boolean;
 }
 
@@ -498,97 +609,6 @@ export class Buffer extends BaseApi {
    * @param {Number} line Line where to place the mark, 0-based.
    * @param {Number} col Column where to place the mark, 0-based.
    * @param {BufferSetExtmarkOptions} opts Optional parameters.
-   *                                       • id : id of the extmark to edit.
-   *                                       • end_row : ending line of the mark, 0-based inclusive.
-   *                                       • end_col : ending col of the mark, 0-based exclusive.
-   *                                       • hl_group : name of the highlight group used to highlight
-   *                                         this mark.
-   *                                       • hl_eol : when true, for a multiline highlight covering the
-   *                                         EOL of a line, continue the highlight for the rest of the
-   *                                         screen line (just like for diff and cursorline highlight).
-   *                                       • virt_text : virtual text to link to this mark. A list of
-   *                                         [text, highlight] tuples, each representing a text chunk
-   *                                         with specified highlight. `highlight` element can either
-   *                                         be a single highlight group, or an array of multiple
-   *                                         highlight groups that will be stacked (highest priority
-   *                                         last). A highlight group can be supplied either as a
-   *                                         string or as an integer, the latter which can be obtained
-   *                                         using nvim_get_hl_id_by_name().
-   *                                       • virt_text_pos : position of virtual text. Possible values:
-   *                                         • "eol": right after eol character (default)
-   *                                         • "overlay": display over the specified column, without
-   *                                           shifting the underlying text.
-   *                                         • "right_align": display right aligned in the window.
-   *
-   *                                       • virt_text_win_col : position the virtual text at a fixed
-   *                                         window column (starting from the first text column)
-   *                                       • virt_text_hide : hide the virtual text when the background
-   *                                         text is selected or hidden due to horizontal scroll
-   *                                         'nowrap'
-   *                                       • hl_mode : control how highlights are combined with the
-   *                                         highlights of the text. Currently only affects virt_text
-   *                                         highlights, but might affect `hl_group` in later versions.
-   *                                         • "replace": only show the virt_text color. This is the
-   *                                           default
-   *                                         • "combine": combine with background text color
-   *                                         • "blend": blend with background text color.
-   *
-   *                                       • virt_lines : virtual lines to add next to this mark This
-   *                                         should be an array over lines, where each line in turn is
-   *                                         an array over [text, highlight] tuples. In general, buffer
-   *                                         and window options do not affect the display of the text.
-   *                                         In particular 'wrap' and 'linebreak' options do not take
-   *                                         effect, so the number of extra screen lines will always
-   *                                         match the size of the array. However the 'tabstop' buffer
-   *                                         option is still used for hard tabs. By default lines are
-   *                                         placed below the buffer line containing the mark.
-   *                                       • virt_lines_above: place virtual lines above instead.
-   *                                       • virt_lines_leftcol: Place extmarks in the leftmost column
-   *                                         of the window, bypassing sign and number columns.
-   *                                       • ephemeral : for use with nvim_set_decoration_provider()
-   *                                         callbacks. The mark will only be used for the current
-   *                                         redraw cycle, and not be permantently stored in the
-   *                                         buffer.
-   *                                       • right_gravity : boolean that indicates the direction the
-   *                                         extmark will be shifted in when new text is inserted (true
-   *                                         for right, false for left). defaults to true.
-   *                                       • end_right_gravity : boolean that indicates the direction
-   *                                         the extmark end position (if it exists) will be shifted in
-   *                                         when new text is inserted (true for right, false for
-   *                                         left). Defaults to false.
-   *                                       • priority: a priority value for the highlight group or sign
-   *                                         attribute. For example treesitter highlighting uses a
-   *                                         value of 100.
-   *                                       • strict: boolean that indicates extmark should not be
-   *                                         placed if the line or column value is past the end of the
-   *                                         buffer or end of the line respectively. Defaults to true.
-   *                                       • sign_text: string of length 1-2 used to display in the
-   *                                         sign column. Note: ranges are unsupported and decorations
-   *                                         are only applied to start_row
-   *                                       • sign_hl_group: name of the highlight group used to
-   *                                         highlight the sign column text. Note: ranges are
-   *                                         unsupported and decorations are only applied to start_row
-   *                                       • number_hl_group: name of the highlight group used to
-   *                                         highlight the number column. Note: ranges are unsupported
-   *                                         and decorations are only applied to start_row
-   *                                       • line_hl_group: name of the highlight group used to
-   *                                         highlight the whole line. Note: ranges are unsupported and
-   *                                         decorations are only applied to start_row
-   *                                       • cursorline_hl_group: name of the highlight group used to
-   *                                         highlight the line when the cursor is on the same line as
-   *                                         the mark and 'cursorline' is enabled. Note: ranges are
-   *                                         unsupported and decorations are only applied to start_row
-   *                                       • conceal: string which should be either empty or a single
-   *                                         character. Enable concealing similar to conceal.
-   *                                         When a character is supplied it is used as cchar.
-   *                                         "hl_group" is used as highlight for the cchar if provided,
-   *                                         otherwise it defaults to Conceal.
-   *                                       • spell: boolean indicating that spell checking should be
-   *                                         performed within this extmark
-   *                                       • ui_watched: boolean that indicates the mark should be
-   *                                         drawn by a UI. When set, the UI will receive win_extmark
-   *                                         events. Note: the mark is positioned by virt_text
-   *                                         attributes. Can be used together with virt_text.
    *
    * @return Id of the created/updated extmark
    */

--- a/packages/neovim/src/api/Tabpage.test.ts
+++ b/packages/neovim/src/api/Tabpage.test.ts
@@ -92,11 +92,16 @@ describe('Tabpage API', () => {
     it('logs an error when calling `getOption`', () => {
       const spy = jest.spyOn(tabpage.logger, 'error');
 
-      tabpage.getOption('option');
+      expect(tabpage.getOption('option')).rejects.toThrow(
+        'Tabpage does not have `getOption`'
+      );
       expect(spy.mock.calls.length).toBe(1);
 
-      tabpage.setOption('option', 'value');
+      expect(tabpage.setOption('option', 'value')).rejects.toThrow(
+        'Tabpage does not have `setOption`'
+      );
       expect(spy.mock.calls.length).toBe(2);
+
       spy.mockClear();
     });
 

--- a/packages/neovim/src/api/Tabpage.ts
+++ b/packages/neovim/src/api/Tabpage.ts
@@ -1,5 +1,6 @@
 import { BaseApi } from './Base';
 import { ExtType, Metadata } from './types';
+import { VimValue } from '../types/VimValue';
 import { createChainableApi } from './helpers/createChainableApi';
 import { Window, AsyncWindow } from './Window';
 
@@ -30,13 +31,17 @@ export class Tabpage extends BaseApi {
   }
 
   /** Invalid */
-  getOption(): void {
-    this.logger.error('Tabpage does not have `getOption`');
+  getOption(): Promise<VimValue> {
+    const message = 'Tabpage does not have `getOption`';
+    this.logger.error(message);
+    return Promise.reject(new Error(message));
   }
 
   /** Invalid */
-  setOption(): void {
-    this.logger.error('Tabpage does not have `setOption`');
+  setOption(): Promise<void> {
+    const message = 'Tabpage does not have `setOption`';
+    this.logger.error(message);
+    return Promise.reject(new Error(message));
   }
 }
 


### PR DESCRIPTION
Fix #170

This PR adds Extmark API binding to `Buffer`. I confirmed it worked on my local:

```javascript
const cp = require('child_process');
const { attach } = require('./packages/neovim');

const proc = cp.spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {});

(async function () {
  const nvim = await attach({ proc });

  const buf = await nvim.buffer;
  await buf.replace(['this is test'], 0);

  const ns = await nvim.createNamespace('test');
  console.log('namespace:', ns);

  const id = await buf.setExtmark(ns, 0, 4);
  console.log('Mark ID:', id);

  const mark = await buf.getExtmarkById(ns, id);
  console.log('Mark:', mark);

  const marks = await buf.getExtmarks(ns, [0, 0], [0, 8]);
  console.log('Marks:', marks);

  const deleted = await buf.deleteExtmark(ns, id);
  console.log('Deleted:', deleted);

  const mark2 = await buf.getExtmarkById(ns, id);
  console.log('Mark after delete:', mark2);

  const marks2 = await buf.getExtmarks(ns, [0, 0], [0, 8]);
  console.log('Marks after delete:', marks2);

  nvim.quit();
  proc.kill();
})().catch(console.error);
```

Output:

```
namespace: 1
Mark ID: 1
Mark: [ 0, 4 ]
Marks: [ [ 1, 0, 4 ] ]
Deleted: true
Mark after delete: []
Marks after delete: []
```

