### PR TITLE
build: remove "resolutions" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "prettier": "^2.4.1",
     "typescript": "^5.1.6"
   },
-  "resolutions": {
-    "jsprim": "1.4.2"
-  },
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "dev": "npm run --stream --parallel dev --workspaces --if-present",


### PR DESCRIPTION
"resolutions" was added in 96ed4d35fb25314a7bb9f9aee564cfd38c7aeff1 but is no longer needed because we don't use yarn since 10a3432b9526ae52e03b88d3adf377b95ed723e2 and npm doesn't support "resolutions".