### PR TITLE
fix: fix types of AsyncWindow/Buffer/Tabpage

### DIFF
--- a/packages/neovim/src/api/Buffer.ts
+++ b/packages/neovim/src/api/Buffer.ts
@@ -1,5 +1,5 @@
 import { BaseApi } from './Base';
-import { ExtType, Metadata } from './types';
+import { ExtType, Metadata, Promisify } from './types';
 
 export interface BufferSetLines {
   start?: number;
@@ -383,4 +383,4 @@ export class Buffer extends BaseApi {
   }
 }
 
-export interface AsyncBuffer extends Buffer, Promise<Buffer> {}
+export interface AsyncBuffer extends Promisify<Buffer>, Promise<Buffer> {}

--- a/packages/neovim/src/api/Neovim.ts
+++ b/packages/neovim/src/api/Neovim.ts
@@ -260,7 +260,8 @@ export class Neovim extends BaseApi {
    * @param {Window} Window handle
    */
   set window(win: AsyncWindow) {
-    this.setWindow(win);
+    if (win instanceof Window) this.setWindow(win);
+    else win.then(win => this.setWindow(win));
   }
 
   /**

--- a/packages/neovim/src/api/Tabpage.ts
+++ b/packages/neovim/src/api/Tabpage.ts
@@ -1,5 +1,5 @@
 import { BaseApi } from './Base';
-import { ExtType, Metadata } from './types';
+import { ExtType, Metadata, Promisify } from './types';
 import { createChainableApi } from './helpers/createChainableApi';
 import { Window, AsyncWindow } from './Window';
 
@@ -40,4 +40,4 @@ export class Tabpage extends BaseApi {
   }
 }
 
-export interface AsyncTabpage extends Tabpage, Promise<Tabpage> {}
+export interface AsyncTabpage extends Promisify<Tabpage>, Promise<Tabpage> {}

--- a/packages/neovim/src/api/Window.ts
+++ b/packages/neovim/src/api/Window.ts
@@ -1,5 +1,5 @@
 import { BaseApi } from './Base';
-import { ExtType, Metadata } from './types';
+import { ExtType, Metadata, Promisify } from './types';
 import { createChainableApi } from './helpers/createChainableApi';
 import { Tabpage, AsyncTabpage } from './Tabpage';
 import { Buffer, AsyncBuffer } from './Buffer';
@@ -118,4 +118,4 @@ export class Window extends BaseApi {
   }
 }
 
-export interface AsyncWindow extends Window, Promise<Window> {}
+export interface AsyncWindow extends Promisify<Window>, Promise<Window> {}

--- a/packages/neovim/src/api/types.ts
+++ b/packages/neovim/src/api/types.ts
@@ -34,3 +34,7 @@ export const Metadata: MetadataType[] = [
     prefix: 'nvim_tabpage_',
   },
 ];
+
+export type Promisify<T> = {
+  [K in keyof T]: Promise<T[K]>;
+};


### PR DESCRIPTION
Wrong type but no error
![image](https://github.com/neovim/node-client/assets/47070852/6886a1ac-005c-4fa2-8ec9-69093b7c4c12)

Correct type but has an error
![image](https://github.com/neovim/node-client/assets/47070852/77e7e2fb-9e4f-4da0-b084-291fe9f10082)
