### PR TITLE
fix(ci): lint on Windows, jest config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         cache: npm
         node-version: ${{ matrix.node }}
 
-    - name: update npm to v8
+    - name: update npm (for node.js 14)
+      if: matrix.node == '14'
       run: npm install -g 'npm@^8.8.0'
 
     - name: install neovim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,8 @@ jobs:
       run: npm run build
 
     - name: lint
-      # Don't run on old node, devDependencies may require newish JS features.
-      # TODO: prettier complains about CRLF on on Windows. Skip for now...
-      if: matrix.node != '14' && runner.os != 'Windows'
+      # Skip on old Node.js, devDependencies use newish JS features.
+      if: matrix.node != '14'
       run: npm run lint
 
     - name: test

--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -87,7 +87,9 @@
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
     "coverageDirectory": "./coverage/",
-    "testURL": "http://localhost"
+    "testEnvironmentOptions": {
+      "url": "http://localhost"
+    }
   },
   "keywords": [
     "neovim",


### PR DESCRIPTION
Problem:
Lint fails on Windows CI, because git converts text to CRLF and prettier expects LF.

Solution:
Disable git's automatic EOL conversion for text files.