### PR TITLE
ci: fix codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - master
   pull_request:
 
+env:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+coverage/
 lib/
 nvimrc
 .DS_Store

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,27 @@
+# https://docs.codecov.com/docs/common-recipe-list#ease-target-coverage
+
 codecov:
   notify:
     require_ci_to_pass: no
 
 coverage:
   precision: 2
-  round: down
-  range: "70...100"
+  round: nearest
+  # https://docs.codecov.com/docs/coverage-configuration#section-range
+  range: '70...95'
 
   status:
-    project: yes
-    patch: yes
+    project:
+      default:
+        # Adjust based on how flaky your tests are.
+        # This allows a x% drop from the previous base commit coverage.
+        threshold: '1%'
+        target: 80%
+    patch:
+      default:
+        only_pulls: true
+        threshold: '1%'
+        target: 80%
     changes: no
 
 parsers:
@@ -17,3 +29,6 @@ parsers:
     enable_partials: yes
 
 comment: off
+
+github_checks:
+    annotations: true

--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -87,6 +87,8 @@
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
     "coverageDirectory": "./coverage/",
+    "collectCoverage": true,
+    "coverageReporters": ["json", "html"],
     "testEnvironmentOptions": {
       "url": "http://localhost"
     }


### PR DESCRIPTION
Problem:

    Error: Codecov token not found. Please provide Codecov token with -t flag.
    ##[warning]Codecov: Failed to properly create commit: The process
    '/Users/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1

Solution:
- Add `CODECOV_TOKEN` as an org secret.
- Pass `CODECOV_TOKEN` in the ci spec.