### PR TITLE
refactor: getNvimFromEnv

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,8 @@ module.exports = {
         // `jest` against the compiled .js results (would require compiling
         // the test files as well)?
         'unicorn/prefer-at': 'off',
-      }
-    }
+      },
+    },
   ],
 
   rules: {
@@ -61,6 +61,7 @@ module.exports = {
 
     // Causes issues with enums
     'no-shadow': 'off',
+    'prefer-destructuring': 'off',  // Intentionally disabled trash.
 
     // prettier things
     'prettier/prettier': 'error',

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # neovim-client
 
-| CI (Linux, macOS, Windows) | Coverage | npm | Gitter |
-|----------------------------|----------|-----|--------|
-| [![ci](https://github.com/neovim/node-client/actions/workflows/ci.yml/badge.svg)](https://github.com/neovim/node-client/actions/workflows/ci.yml) | [![Coverage Badge][]][Coverage Report] | [![npm version][]][npm package] | [![Gitter Badge][]][Gitter] |
-
-Currently tested for node >= 10
+| CI (node >= 14, Linux/macOS/Windows) | Coverage | npm |
+|----------------------------|----------|-----|
+| [![ci](https://github.com/neovim/node-client/actions/workflows/ci.yml/badge.svg)](https://github.com/neovim/node-client/actions/workflows/ci.yml) | [![Coverage Badge][]][Coverage Report] | [![npm version][]][npm package] |
 
 ## Installation
 Install the `neovim` package globally using `npm`.
 
-```sh
+```bash
 npm install -g neovim
 ```
 
 A global package is required for neovim to be able to communicate with a plugin.
 
 ## Usage
-This package exports a single `attach()` function which takes a pair of
+The `neovim` package exports a single `attach()` function which takes a pair of
 write/read streams and invokes a callback with a Nvim API object.
 
 ### `attach`
@@ -176,5 +174,3 @@ The tests and [`scripts`](https://github.com/neovim/node-client/tree/master/pack
 [Coverage Report]: https://codecov.io/gh/neovim/node-client
 [npm version]: https://img.shields.io/npm/v/neovim.svg
 [npm package]: https://www.npmjs.com/package/neovim
-[Gitter Badge]: https://badges.gitter.im/neovim/node-client.svg
-[Gitter]: https://gitter.im/neovim/node-client?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,4 +31,4 @@ parsers:
 comment: off
 
 github_checks:
-    annotations: true
+  annotations: true

--- a/packages/neovim/src/utils/getNvimFromEnv.ts
+++ b/packages/neovim/src/utils/getNvimFromEnv.ts
@@ -11,52 +11,43 @@ export type NvimVersion = {
 
 export type GetNvimFromEnvOptions = {
   /**
-   * The minimum version of nvim to get. This is optional.
+   * (Optional) Minimum `nvim` version (inclusive) to search for.
    *
    * - Example: `'0.5.0'`
-   * - Note: This is inclusive.
-   * - Note: If this is not set, then there is no minimum version.
    */
   readonly minVersion?: string;
   /**
-   * The order to return the nvim versions in. This is optional.
+   * (Optional) Sort order of list of `nvim` versions.
    *
-   * - `latest_nvim_first` - The latest version of nvim will be first. This is the default.
+   * - `latest_nvim_first` - Latest Nvim version will be first.
    *   - Example: `['0.5.0', '0.4.4', '0.4.3']`
-   *   - Note: This will be slower than `latest_nvim_first`.
-   * - `keep_path` - The order of the nvim versions will be the same as the order of the paths in the `PATH` environment variable.
+   * - `keep_path` - (Default) Order is that of the searched `$PATH` components.
    *   - Example: `['0.4.4', '0.5.0', '0.4.3']`
-   *   - Note: This will be faster than `latest_nvim_first`.
-   *   - this is the default.
    */
   readonly orderBy?: 'latest_nvim_first' | 'keep_path';
 };
 
 export type GetNvimFromEnvError = {
-  /** The executeable path that failed. */
+  /** Executeable path that failed. */
   readonly path: string;
-  /** The catched error */
+  /** Error caught during operation. */
   readonly exception: Readonly<Error>;
 };
 
 export type GetNvimFromEnvResult = {
   /**
-   * A list of nvim versions that match the minimum version.
-   * This will be empty if no matching versions were found.
-   * This will be sorted in the order specified by `orderBy`.
+   * List of satisfying `nvim` versions found on the current system.
+   * Empty if no matching versions were found.
+   * Sorted in the order specified by `orderBy`.
    */
   readonly matches: ReadonlyArray<NvimVersion>;
   /**
-   * A list of nvim versions that do not match the minimum version.
-   * This will be empty if all versions match the minimum version or if no minimum version was specified.
-   * This will not be sorted (it will be in the order of the paths in the `PATH` environment variable).
+   * List of invalid `nvim` versions found (if any), in order of searched `$PATH` components.
    */
   readonly unmatchedVersions: ReadonlyArray<NvimVersion>;
   /**
-   * A list of errors that occurred while trying to get the nvim versions.
-   * This will be empty if no errors occurred.
-   * This will not be sorted (it will be in the order of the paths in the `PATH` environment variable).
-   * Unmatched versions are not treated as errors.
+   * List of errors collected while trying to get the nvim versions (if any), in order of searched
+   * `$PATH` components. Unmatched versions are not treated as errors.
    */
   readonly errors: ReadonlyArray<GetNvimFromEnvError>;
 };


### PR DESCRIPTION
- don't export `parseVersion`, `compareVersions`
- rename options
- add test coverage
- remove TypeErrors for conditions which cannot happen (thus aren't testable)