### PR TITLE
fix: getNvimFromEnv returns invalid Nvim in matches

### DIFF
--- a/packages/integration-tests/__tests__/integration.test.ts
+++ b/packages/integration-tests/__tests__/integration.test.ts
@@ -43,7 +43,7 @@ describe('Node host', () => {
       ['-u', nvimrc, '-i', 'NONE', '--headless', '--embed', '-n'],
       {}
     );
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {
@@ -60,7 +60,7 @@ describe('Node host', () => {
 
   // it.skip('should return specs', async done => {
   // const proc = cp.spawn('nvim', args.concat(['--embed']));
-  // const nvim = await attach({ proc });
+  // const nvim = attach({ proc });
   // nvim.command('UpdateRemotePlugins');
   // done();
   // });

--- a/packages/neovim/README.md
+++ b/packages/neovim/README.md
@@ -29,7 +29,7 @@ const nvim_proc = cp.spawn('nvim', ['-u', 'NONE', '-N', '--embed'], {});
 
 // Attach to neovim process
 (async function() {
-  const nvim = await attach({ proc: nvim_proc });
+  const nvim = attach({ proc: nvim_proc });
   nvim.command('vsp');
   nvim.command('vsp');
   nvim.command('vsp');

--- a/packages/neovim/scripts/nvim.js
+++ b/packages/neovim/scripts/nvim.js
@@ -24,6 +24,6 @@ module.exports = (async function () {
     });
   }
 
-  const nvim = await attach({ proc, socket });
+  const nvim = attach({ proc, socket });
   return nvim;
 })();

--- a/packages/neovim/src/api/Buffer.test.ts
+++ b/packages/neovim/src/api/Buffer.test.ts
@@ -52,7 +52,7 @@ describe('Buffer API', () => {
       cwd: __dirname,
     });
 
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {
@@ -414,7 +414,7 @@ describe('Buffer event updates', () => {
       cwd: __dirname,
     });
 
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {

--- a/packages/neovim/src/api/Neovim.test.ts
+++ b/packages/neovim/src/api/Neovim.test.ts
@@ -26,7 +26,7 @@ describe('Neovim API', () => {
       cwd: __dirname,
     });
 
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {

--- a/packages/neovim/src/api/Tabpage.test.ts
+++ b/packages/neovim/src/api/Tabpage.test.ts
@@ -24,7 +24,7 @@ describe('Tabpage API', () => {
       cwd: __dirname,
     });
 
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {

--- a/packages/neovim/src/api/Window.test.ts
+++ b/packages/neovim/src/api/Window.test.ts
@@ -25,7 +25,7 @@ describe('Window API', () => {
       cwd: __dirname,
     });
 
-    nvim = await attach({ proc });
+    nvim = attach({ proc });
   });
 
   afterAll(() => {

--- a/packages/neovim/src/attach/attach.test.ts
+++ b/packages/neovim/src/attach/attach.test.ts
@@ -27,7 +27,7 @@ describe('Nvim Promise API', () => {
         cwd: __dirname,
       });
 
-      nvim = await attach({ proc });
+      nvim = attach({ proc });
       nvim.on('request', (method, args, resp) => {
         requests.push({ method, args });
         resp.send(`received ${method}(${args})`);


### PR DESCRIPTION
Problem:
If a found "nvim" does not meet `minVersion`, it's included in _both_ `matches` and `unmatchedVersions`. It should only be included in `unmatchedVersions`.

Solution:

- If a found "nvim" is broken or does not meet `minVersion`, do not  include it in matches.
- Merge the `unmatchedVersions` and `errors` collections into a single  `invalid` list.