### PR TITLE
fix(logger): use custom logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix: console.log() writes to RPC channel #202 #329
 - feat: eliminate `which` dependency
 - feat: improve logs + error messages
+- fix: always use custom logger if one is given
 
 ## [5.0.1](https://github.com/neovim/node-client/compare/v4.11.0...v5.0.1) (2024-03-01)
 

--- a/packages/neovim/bin/cli.js
+++ b/packages/neovim/bin/cli.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 const { Host } = require('../lib/host');
-const { getLogger } = require('../lib/utils/logger');
 const { spawnSync } = require('child_process');
 
 // node <current script> <rest of args>
@@ -35,9 +34,9 @@ try {
   const host = new Host(args);
   host.start({ proc: process });
 } catch (err) {
-  getLogger().error(err);
+  process.stderr.write(`failed to start Nvim plugin host: ${err.name}: ${err.message}\n`);
 }
 
 process.on('unhandledRejection', (reason, p) => {
-  getLogger().info('Unhandled Rejection at:', p, 'reason:', reason);
+  process.stderr.write(`Unhandled Rejection at: ${p} reason: ${reason}\n`);
 });

--- a/packages/neovim/bin/cli.js
+++ b/packages/neovim/bin/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const { Host } = require('../lib/host');
-const { logger } = require('../lib/utils/logger');
+const { getLogger } = require('../lib/utils/logger');
 const { spawnSync } = require('child_process');
 
 // node <current script> <rest of args>
@@ -35,9 +35,9 @@ try {
   const host = new Host(args);
   host.start({ proc: process });
 } catch (err) {
-  logger.error(err);
+  getLogger().error(err);
 }
 
 process.on('unhandledRejection', (reason, p) => {
-  logger.info('Unhandled Rejection at:', p, 'reason:', reason);
+  getLogger().info('Unhandled Rejection at:', p, 'reason:', reason);
 });

--- a/packages/neovim/src/api/Base.ts
+++ b/packages/neovim/src/api/Base.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 
 import { Transport } from '../utils/transport';
-import { Logger } from '../utils/logger';
+import { Logger, getLogger } from '../utils/logger';
 import { VimValue } from '../types/VimValue';
 
 export interface BaseConstructorOptions {
@@ -50,7 +50,7 @@ export class BaseApi extends EventEmitter {
     this.setTransport(transport);
     this.data = data;
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    this.logger = logger || require('../utils/logger').logger;
+    this.logger = logger || getLogger();
     this.client = client;
 
     if (metadata) {
@@ -82,10 +82,7 @@ export class BaseApi extends EventEmitter {
       });
     });
 
-  async asyncRequest(
-    name: string,
-    args: any[] = [],
-  ): Promise<any> {
+  async asyncRequest(name: string, args: any[] = []): Promise<any> {
     // `this._isReady` is undefined in ExtType classes (i.e. Buffer, Window, Tabpage)
     // But this is just for Neovim API, since it's possible to call this method from Neovim class
     // before transport is ready.

--- a/packages/neovim/src/api/Base.ts
+++ b/packages/neovim/src/api/Base.ts
@@ -73,7 +73,7 @@ export class BaseApi extends EventEmitter {
   [DO_REQUEST] = (name: string, args: any[] = []): Promise<any> =>
     new Promise((resolve, reject) => {
       this.transport.request(name, args, (err: any, res: any) => {
-        this.logger.debug(`response -> neovim.api.${name}: ${res}`);
+        this.logger.debug(`response -> ${name}: ${res}`);
         if (err) {
           reject(new Error(`${name}: ${err[1]}`));
         } else {
@@ -85,7 +85,6 @@ export class BaseApi extends EventEmitter {
   async asyncRequest(
     name: string,
     args: any[] = [],
-    stack: string | undefined = undefined
   ): Promise<any> {
     // `this._isReady` is undefined in ExtType classes (i.e. Buffer, Window, Tabpage)
     // But this is just for Neovim API, since it's possible to call this method from Neovim class
@@ -93,11 +92,11 @@ export class BaseApi extends EventEmitter {
     // Not possible for ExtType classes since they are only created after transport is ready
     await this._isReady;
 
-    this.logger.debug(`request -> neovim.api.${name}`);
+    this.logger.debug(`request -> ${name}`);
 
     return this[DO_REQUEST](name, args).catch(err => {
+      // XXX: Get a `*.ts stacktrace. If we re-throw `err` we get a `*.js` trace. tsconfig issue?
       const newError = new Error(err.message);
-      newError.stack = stack;
       this.logger.error(
         `failed request to "%s": %s: %s`,
         name,
@@ -109,12 +108,7 @@ export class BaseApi extends EventEmitter {
   }
 
   request(name: string, args: any[] = []): Promise<any> {
-    // Dummy error, to get stacktrace.
-    const error = new Error(
-      `failed request to "${name}" (see $NVIM_NODE_LOG_FILE for details, if it was set)`
-    );
-
-    return this.asyncRequest(name, args, error.stack);
+    return this.asyncRequest(name, args);
   }
 
   _getArgsByPrefix(...args: any[]): any[] {
@@ -169,7 +163,7 @@ export class BaseApi extends EventEmitter {
   // TODO: Is this necessary?
   /** `request` is basically the same except you can choose to wait forpromise to be resolved */
   notify(name: string, args: any[]): void {
-    this.logger.debug(`notify -> neovim.api.${name}`);
+    this.logger.debug(`notify -> ${name}`);
     this.transport.notify(name, args);
   }
 }

--- a/packages/neovim/src/api/client.ts
+++ b/packages/neovim/src/api/client.ts
@@ -1,7 +1,7 @@
 /**
  * Handles attaching transport
  */
-import { logger } from '../utils/logger';
+import { Logger } from '../utils/logger';
 import { Transport } from '../utils/transport';
 import { VimValue } from '../types/VimValue';
 import { Neovim } from './Neovim';
@@ -18,7 +18,7 @@ export class NeovimClient extends Neovim {
 
   private attachedBuffers: Map<string, Map<string, Function[]>> = new Map();
 
-  constructor(options: { transport?: Transport; logger?: typeof logger } = {}) {
+  constructor(options: { transport?: Transport; logger?: Logger } = {}) {
     // Neovim has no `data` or `metadata`
     super({
       logger: options.logger,

--- a/packages/neovim/src/attach/attach.ts
+++ b/packages/neovim/src/attach/attach.ts
@@ -2,7 +2,7 @@ import { createConnection } from 'node:net';
 import * as child from 'node:child_process';
 
 import { NeovimClient } from '../api/client';
-import { Logger } from '../utils/logger';
+import { Logger, getLogger } from '../utils/logger';
 
 export interface Attach {
   reader?: NodeJS.ReadableStream;
@@ -38,7 +38,7 @@ export function attach({
 
   if (writer && reader) {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
-    const loggerInstance = options.logger || require('../utils/logger').logger; // lazy load to winston only if needed
+    const loggerInstance = options.logger || getLogger(); // lazy load to winston only if needed
     const neovim = new NeovimClient({ logger: loggerInstance });
     neovim.attach({
       writer,

--- a/packages/neovim/src/host/NvimPlugin.test.ts
+++ b/packages/neovim/src/host/NvimPlugin.test.ts
@@ -1,12 +1,14 @@
 /* eslint-env jest */
+import { getFakeNvimClient } from '../testUtil';
 import { callable, NvimPlugin } from './NvimPlugin';
 
 describe('NvimPlugin', () => {
   it('should initialise variables', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const fakeNvimClient = getFakeNvimClient();
+    const plugin = new NvimPlugin('/tmp/filename', () => {}, fakeNvimClient);
 
     expect(plugin.filename).toEqual('/tmp/filename');
-    expect(plugin.nvim).toEqual({});
+    expect(plugin.nvim).toEqual(fakeNvimClient);
     expect(plugin.dev).toBe(false);
     expect(Object.keys(plugin.autocmds)).toHaveLength(0);
     expect(Object.keys(plugin.commands)).toHaveLength(0);
@@ -14,14 +16,22 @@ describe('NvimPlugin', () => {
   });
 
   it('should set dev options when you call setOptions', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     plugin.setOptions({ dev: true });
     expect(plugin.dev).toBe(true);
     expect(plugin.shouldCacheModule).toBe(false);
   });
 
   it('should store registered autocmds', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const fn = () => {};
     const opts = { pattern: '*' };
     const spec = {
@@ -36,7 +46,11 @@ describe('NvimPlugin', () => {
   });
 
   it('should store registered commands', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const fn = () => {};
     const opts = { sync: true };
     const spec = {
@@ -51,7 +65,11 @@ describe('NvimPlugin', () => {
   });
 
   it('should store registered functions', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const fn = () => {};
     const opts = { sync: true };
     const spec = {
@@ -66,7 +84,11 @@ describe('NvimPlugin', () => {
   });
 
   it('should not add autocmds with no pattern option', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     plugin.registerAutocmd('BufWritePre', () => {}, { pattern: '' });
     expect(Object.keys(plugin.autocmds)).toHaveLength(0);
   });
@@ -82,7 +104,11 @@ describe('NvimPlugin', () => {
     const thisObj = {};
     expect(callable([thisObj, fn])()).toBe(thisObj);
 
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const obj = {
       func: jest.fn(function () {
         return this;
@@ -97,13 +123,21 @@ describe('NvimPlugin', () => {
   });
 
   it('should not register commands with incorrect callable arguments', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     plugin.registerCommand('MyCommand', [], {});
     expect(Object.keys(plugin.commands)).toHaveLength(0);
   });
 
   it('should return specs for registered commands', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const fn = () => {};
     const aOpts = { pattern: '*' };
     const aSpec = {
@@ -136,7 +170,11 @@ describe('NvimPlugin', () => {
   });
 
   it('should handle requests for registered commands', async () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     const fn = arg => arg;
 
     plugin.registerAutocmd('BufWritePre', fn, { pattern: '*', sync: true });
@@ -155,7 +193,11 @@ describe('NvimPlugin', () => {
   });
 
   it('should throw on unknown request', () => {
-    const plugin = new NvimPlugin('/tmp/filename', () => {}, {});
+    const plugin = new NvimPlugin(
+      '/tmp/filename',
+      () => {},
+      getFakeNvimClient()
+    );
     expect.assertions(1);
     plugin.handleRequest('BufWritePre *', 'autocmd', [true]).catch(err => {
       expect(err).toEqual(

--- a/packages/neovim/src/host/NvimPlugin.ts
+++ b/packages/neovim/src/host/NvimPlugin.ts
@@ -1,6 +1,5 @@
 /* eslint import/export:0 */
 import { Neovim } from '../api/Neovim';
-import { logger } from '../utils/logger';
 import { Spec } from '../types/Spec';
 
 export interface NvimPluginOptions {
@@ -108,7 +107,9 @@ export class NvimPlugin {
 
   registerAutocmd(name: string, fn: any, options?: AutocmdOptions): void {
     if (!options.pattern) {
-      logger.error(`registerAutocmd expected pattern option for ${name}`);
+      this.nvim.logger.error(
+        `registerAutocmd expected pattern option for ${name}`
+      );
       return;
     }
 
@@ -131,7 +132,9 @@ export class NvimPlugin {
         spec,
       };
     } catch (err) {
-      logger.error(`registerAutocmd expected callable argument for ${name}`);
+      this.nvim.logger.error(
+        `registerAutocmd expected callable argument for ${name}`
+      );
     }
   }
 
@@ -163,7 +166,9 @@ export class NvimPlugin {
         spec,
       };
     } catch (err) {
-      logger.error(`registerCommand expected callable argument for ${name}`);
+      this.nvim.logger.error(
+        `registerCommand expected callable argument for ${name}`
+      );
     }
   }
 
@@ -199,7 +204,9 @@ export class NvimPlugin {
         spec,
       };
     } catch (err) {
-      logger.error(`registerFunction expected callable argument for ${name}`);
+      this.nvim.logger.error(
+        `registerFunction expected callable argument for ${name}`
+      );
     }
   }
 
@@ -231,7 +238,7 @@ export class NvimPlugin {
         break;
       default:
         const errMsg = `No handler for unknown type ${type}: "${name}" in ${this.filename}`;
-        logger.error(errMsg);
+        this.nvim.logger.error(errMsg);
         throw new Error(errMsg);
     }
 
@@ -243,12 +250,14 @@ export class NvimPlugin {
           : await handler.fn(...args);
       } catch (err) {
         const msg = `Error in plugin for ${type}:${name}: ${err.message}`;
-        logger.error(`${msg} (file: ${this.filename}, stack: ${err.stack})`);
+        this.nvim.logger.error(
+          `${msg} (file: ${this.filename}, stack: ${err.stack})`
+        );
         throw new Error(err);
       }
     } else {
       const errMsg = `Missing handler for ${type}: "${name}" in ${this.filename}`;
-      logger.error(errMsg);
+      this.nvim.logger.error(errMsg);
       throw new Error(errMsg);
     }
   }

--- a/packages/neovim/src/host/factory.ts
+++ b/packages/neovim/src/host/factory.ts
@@ -2,7 +2,6 @@ import * as path from 'node:path';
 import Module = require('module');
 
 import { Neovim } from '../api/Neovim';
-import { logger } from '../utils/logger';
 
 import { NvimPlugin } from './NvimPlugin';
 
@@ -17,7 +16,7 @@ function createPlugin(
   options: LoadPluginOptions = {}
 ): NvimPlugin | null {
   try {
-    logger.debug(
+    nvim.logger.debug(
       `createPlugin.${filename}.clearCache: ${options && !options.cache}`
     );
 
@@ -42,8 +41,8 @@ function createPlugin(
     }
   } catch (err) {
     const file = path.basename(filename);
-    logger.error(`[${file}] ${err.stack}`);
-    logger.error(`[${file}] Error loading child ChildPlugin ${filename}`);
+    nvim.logger.error(`[${file}] ${err.stack}`);
+    nvim.logger.error(`[${file}] Error loading child ChildPlugin ${filename}`);
   }
 
   // There may have been an error, but maybe not

--- a/packages/neovim/src/plugin/plugin.test.ts
+++ b/packages/neovim/src/plugin/plugin.test.ts
@@ -4,6 +4,7 @@ import { NvimPlugin } from '../host/NvimPlugin';
 import { nvimFunction as FunctionDecorator } from './function';
 import { command as Command } from './command';
 import { autocmd as Autocmd } from './autocmd';
+import { getFakeNvimClient } from '../testUtil';
 
 const instantiateOrRun = (Fn, ...args) => {
   try {
@@ -29,7 +30,7 @@ describe('Plugin class decorator', () => {
     const plugin = Plugin({ dev: true })(MyClass);
     expect(typeof plugin).toEqual('function');
 
-    const pluginObject = { setOptions: jest.fn() };
+    const pluginObject = { setOptions: jest.fn(), nvim: getFakeNvimClient() };
     instantiateOrRun(plugin, pluginObject);
     expect(pluginObject.setOptions).toHaveBeenCalledWith({ dev: true });
   });
@@ -60,6 +61,7 @@ describe('Plugin class decorator', () => {
       registerAutocmd: jest.fn(),
       registerCommand: jest.fn(),
       registerFunction: jest.fn(),
+      nvim: getFakeNvimClient(),
     };
 
     const instance = instantiateOrRun(plugin, pluginObject);
@@ -102,7 +104,11 @@ describe('Plugin class decorator', () => {
 
     const plugin = Plugin(MyClass);
 
-    const pluginObject = new NvimPlugin('/tmp/filename', plugin, {});
+    const pluginObject = new NvimPlugin(
+      '/tmp/filename',
+      plugin,
+      getFakeNvimClient()
+    );
 
     expect(pluginObject.specs).toEqual([
       {

--- a/packages/neovim/src/plugin/plugin.ts
+++ b/packages/neovim/src/plugin/plugin.ts
@@ -1,6 +1,5 @@
 /* eslint no-shadow:0, import/export:0 */
 // Plugin decorator
-import { logger } from '../utils/logger';
 
 import { NVIM_SPEC } from './properties';
 import { Neovim } from '../api/Neovim';
@@ -26,8 +25,6 @@ function wrapper<T extends Constructor<{}>>(
   cls: T,
   options?: PluginDecoratorOptions
 ) {
-  logger.info(`Decorating class ${cls}`);
-
   return class extends cls {
     public nvim: Neovim;
 
@@ -39,14 +36,15 @@ function wrapper<T extends Constructor<{}>>(
       if (options) {
         plugin.setOptions(options);
       }
+      plugin.nvim.logger.info(`Decorating class ${cls}`);
 
       // Search for decorated methods
       Object.getOwnPropertyNames(cls.prototype).forEach(methodName => {
-        logger.info(`Method name ${methodName}`);
-        logger.info(
+        plugin.nvim.logger.info(`Method name ${methodName}`);
+        plugin.nvim.logger.info(
           `${cls.prototype[methodName]} ${typeof cls.prototype[methodName]}`
         );
-        logger.info(`${this} ${typeof this}`);
+        plugin.nvim.logger.info(`${this} ${typeof this}`);
 
         const method = cls.prototype[methodName];
         if (method && method[NVIM_SPEC]) {

--- a/packages/neovim/src/testUtil.ts
+++ b/packages/neovim/src/testUtil.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { NeovimClient } from './api/client';
 import { attach } from './attach';
 import { findNvim } from './utils/findNvim';
+import { getLogger } from './utils/logger';
 
 export function findNvimOrFail() {
   const minVersion = '0.9.5';
@@ -68,6 +69,12 @@ export function stopNvim(
   } else if (proc_ && proc_.connected) {
     proc_.disconnect();
   }
+}
+
+export function getFakeNvimClient() {
+  return {
+    logger: getLogger(),
+  } as NeovimClient;
 }
 
 // jest.beforeAll(async () => {

--- a/packages/neovim/src/utils/logger.ts
+++ b/packages/neovim/src/utils/logger.ts
@@ -59,4 +59,10 @@ function setupWinstonLogger(): Logger {
   return logger;
 }
 
-export const logger: Logger = setupWinstonLogger();
+let _logger: Logger; // singleton
+export function getLogger() {
+  if (!_logger) {
+    _logger = setupWinstonLogger();
+  }
+  return _logger;
+}


### PR DESCRIPTION
Problem:
- d9bc2efe30cd4c0de3691e953cace04d02e7855f #138 allows clients to supply a custom logger, but the logger is not always used.
- The winstonLogger is always initialized, even when a custom logger is given.

Solution:
- Update all logging calls to use the custom logger.
- Skip initialization of winstonLogger if a custom logger is given.
