### PR TITLE
feat(logger): timestamp, pretty-print objects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,8 @@ module.exports = {
         functions: 'ignore',
       },
     ],
+    // airbnb discourages "for..of", wtf? https://github.com/airbnb/javascript/issues/1271#issuecomment-548688952
+    'no-restricted-syntax': 'off',
     'no-case-declarations': 'off',
     'no-prototype-builtins': 'off',
     'no-underscore-dangle': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  # Purpose of this (currently) is to exercise related codepaths.
+  # Set NVIM_NODE_LOG_FILE to exercise related codepaths.
   NVIM_NODE_LOG_FILE: 'node-client.test.log'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - fix: console.log() writes to RPC channel #202 #329
 - feat: eliminate `which` dependency
 - feat: improve logs + error messages
-- fix: always use custom logger if one is given
+- fix: always use custom logger if one is given #336
+- feat(logger): timestamp, pretty-print objects #337
 
 ## [5.0.1](https://github.com/neovim/node-client/compare/v4.11.0...v5.0.1) (2024-03-01)
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Following is a complete, working example.
        const found = findNvim({ orderBy: 'desc', minVersion: '0.9.0' })
        console.log(found);
        const nvim_proc = child_process.spawn(found.matches[0].path, ['--clean', '--embed'], {});
-
        const nvim = attach({ proc: nvim_proc });
+
        nvim.command('vsp | vsp | vsp');
 
        const windows = await nvim.windows;
@@ -81,7 +81,6 @@ Following is a complete, working example.
        const newLines = await buf.lines;
        assert.deepStrictEqual(newLines, ['line1', 'line2']);
 
-       // console.log('%O', nvim_proc);
        if (nvim_proc.disconnect) {
          nvim_proc.disconnect();
        }

--- a/packages/neovim/src/attach/attach.ts
+++ b/packages/neovim/src/attach/attach.ts
@@ -37,7 +37,6 @@ export function attach({
   }
 
   if (writer && reader) {
-    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     const loggerInstance = options.logger || getLogger(); // lazy load to winston only if needed
     const neovim = new NeovimClient({ logger: loggerInstance });
     neovim.attach({

--- a/packages/neovim/src/plugin/autocmd.ts
+++ b/packages/neovim/src/plugin/autocmd.ts
@@ -29,9 +29,7 @@ export function autocmd(name: string, options?: AutocmdOptions) {
       }
     });
 
-    const nameWithPattern = `${name}${
-      options.pattern ? `:${options.pattern}` : ''
-    }`;
+    const nameWithPattern = `${name}${options.pattern ? `:${options.pattern}` : ''}`;
     Object.defineProperty(f, NVIM_METHOD_NAME, {
       value: `autocmd:${nameWithPattern}`,
     });

--- a/packages/neovim/src/testUtil.ts
+++ b/packages/neovim/src/testUtil.ts
@@ -34,7 +34,6 @@ export function startNvim(
 ): [cp.ChildProcessWithoutNullStreams, NeovimClient | undefined] {
   const testFile = jest.expect.getState().testPath?.replace(/.*[\\/]/, '');
   const msg = `startNvim in test: ${testFile}`;
-  // console.log(msg);
   if (process.env.NVIM_NODE_LOG_FILE) {
     const logfile = path.resolve(process.env.NVIM_NODE_LOG_FILE);
     fs.writeFileSync(logfile, `${msg}\n`, { flag: 'a' });

--- a/packages/neovim/src/utils/util.ts
+++ b/packages/neovim/src/utils/util.ts
@@ -1,0 +1,52 @@
+/**
+ * Clones an object (copies "own properties") until `depth`, where:
+ * - depth=0 returns non-object value, or empty object (`{}` or `[]`).
+ * - depth=1 returns `obj` with its immediate children (but not their children).
+ * - depth=2 returns `obj` with its children and their children.
+ * - and so on...
+ *
+ * TODO: node's `util.inspect()` function is better, but doesn't work in web browser?
+ *
+ * @param obj Object to clone.
+ * @param depth
+ * @param omitKeys Omit properties matching these names (at any depth).
+ * @param replacement Replacement for object whose fields extend beyond `depth`, and properties matching `omitKeys`.
+ */
+export function partialClone(
+  obj: any,
+  depth: number = 3,
+  omitKeys: string[] = [],
+  replacement: any = undefined
+): any {
+  // Base case: If input is not an object or has no children, return it.
+  if (
+    typeof obj !== 'object' ||
+    obj === null ||
+    Object.getOwnPropertyNames(obj).length === 0
+  ) {
+    return obj;
+  }
+
+  // Create a new object of the same type as the input object.
+  const clonedObj = Array.isArray(obj) ? [] : {};
+
+  if (depth === 0) {
+    return replacement || clonedObj;
+  }
+
+  // Recursively clone properties of the input object
+  for (const key of Object.keys(obj)) {
+    if (omitKeys.includes(key)) {
+      (clonedObj as any)[key] = replacement || (Array.isArray(obj) ? [] : {});
+    } else if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      (clonedObj as any)[key] = partialClone(
+        obj[key],
+        depth - 1,
+        omitKeys,
+        replacement
+      );
+    }
+  }
+
+  return clonedObj;
+}


### PR DESCRIPTION
BEFORE:

    info: [object Object]
    debug: request -> nvim_command
    debug: request -> nvim_list_wins
    debug: response -> nvim_command: null
    debug: response -> nvim_list_wins: [object Object],[object Object],[object Object],[object Object]
    ...

AFTER:

    2024-03-20 11:37:25 INF {
      matches: [
        {
          nvimVersion: '0.10.0-dev-2657+g9765efb40f57',
          path: '/usr/local/bin/nvim',
          buildType: 'RelWithDebInfo',
          luaJitVersion: '2.1.1710088188'
        }
      ],
      invalid: []
    }
    2024-03-20 11:37:25 DBG request  -> nvim_command
    2024-03-20 11:37:25 DBG request  -> nvim_list_wins
    2024-03-20 11:37:25 DBG response -> nvim_command: null
    2024-03-20 11:37:25 DBG response -> nvim_list_wins: [
      {
        _events: [Object: null prototype] {},
        _eventsCount: 0,
        _maxListeners: undefined,
        transport: '[Object]',
        data: 1003,
        logger: '[Object]',
        client: '[Object]',
        prefix: 'nvim_win_'
      },
      {
        _events: [Object: null prototype] {},
        _eventsCount: 0,
        _maxListeners: undefined,
        transport: '[Object]',
        data: 1002,
        logger: '[Object]',
        client: '[Object]',
        prefix: 'nvim_win_'
      },
      ...
    ]
    ...
    2024-03-20 11:37:25 DBG request  -> nvim_buf_get_lines
    2024-03-20 11:37:25 DBG response -> nvim_buf_get_lines: [ 'line1', 'line2' ]