### PR TITLE
Add name and version to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Only maintainers of the [neovim NPM package](https://www.npmjs.com/package/neovi
 2. Update version. Build and publish the package. Tag the release and push.
    ```bash
    # Choose major/minor/patch as needed.
+   npm version patch
    npm version -w packages/neovim/ patch
    git commit -m 'release'
    # Note: this copies the top-level README.md/CHANGELOG.md to packages/neovim/.
@@ -231,6 +232,7 @@ Only maintainers of the [neovim NPM package](https://www.npmjs.com/package/neovi
    ```
 3. Post-release tasks:
    ```bash
+   npm version --no-git-tag-version prerelease --preid dev
    npm version -w packages/neovim/ --no-git-tag-version prerelease --preid dev
    git add packages/*/package.json package*.json && git commit -m bump
    git push

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "neovim",
+  "version": "5.1.1-dev.0",
   "private": true,
   "workspaces": [
     "packages/neovim",


### PR DESCRIPTION
I'm trying to build node-client on nix using buildNpmPackages, as nix is migrating away from the old way of building node packages, and I get the following:

```
error: builder for '/nix/store/yp8wvva7jzd0z1p6myafvc7h6j2baiax-neovim-node-client-5.1.0.drv' failed with exit code 1;
       last 25 log lines:
       >
       >
       > > @neovim/integration-tests@4.10.1 build
       > > tsc --pretty
       >
       >
       > > @neovim/example-plugin-decorators@4.10.1 build
       > > babel src --out-dir lib
       >
       > Successfully compiled 2 files with Babel (132ms).
       > Finished npmBuildHook
       > Running phase: installPhase
       > Executing npmInstallHook
       > npm ERR! Invalid package, must have name and version
```

This seems to be solved simply by adding the name/version into package.json, which this PR does. I've confirmed that the it builds/works correctly with this change, so didn't investigate what exact command was causing the issue in the install hook.