### PR TITLE
ci: add node 20, drop node 14/16 on mac/win

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['14', '16', '18']
+        node: ['14', '16', '18', '20']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        exclude:
+        - os: macos-latest
+          node: '14'
+        - os: macos-latest
+          node: '16'
+        - os: windows-latest
+          node: '14'
+        - os: windows-latest
+          node: '16'
         include:
         - os: ubuntu-latest
           NIGHTLY: nvim-linux64.tar.gz


### PR DESCRIPTION
Problem:
macos CI fails:

    Error: Unable to find Node version '14' for platform darwin and architecture arm64.

Solution:
- Skip node 14/16 on macos and windows (to save CI time).
- Add testing for node 20.