### PR TITLE
fix(logger): console.assert() throws exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [5.3.0](https://github.com/neovim/node-client/compare/v5.2.0...v5.3.0)
 
-- TBD
+- fix(logger): console.assert() throws exception
 
 ## [5.2.0](https://github.com/neovim/node-client/compare/v5.1.0...v5.2.0)
 

--- a/packages/neovim/src/attach/attach.test.ts
+++ b/packages/neovim/src/attach/attach.test.ts
@@ -47,6 +47,17 @@ describe('Nvim API', () => {
     expect(await nvim.eval('1+1')).toEqual(2);
   });
 
+  it('console.assert is monkey-patched', async () => {
+    const spy = jest.spyOn(nvim.logger, 'error');
+    // eslint-disable-next-line no-console
+    console.assert(false, 'foo', 42, { x: [1, 2] });
+    expect(spy).toHaveBeenCalledWith('assertion failed', 'foo', 42, {
+      x: [1, 2],
+    });
+    // Still alive?
+    expect(await nvim.eval('1+1')).toEqual(2);
+  });
+
   it('console.log NOT monkey-patched if custom logger passed to attach()', async () => {
     const [proc2] = testUtil.startNvim(false);
     const logged: string[] = [];


### PR DESCRIPTION
## Problem:
Exception when calling `console.assert()`.
Example from https://github.com/vscode-neovim/vscode-neovim/issues/2242 :

    {"tag":"dap.send","timestamp":1726115647837,"metadata":{"connectionId":3,"message":{"seq":1,"type":"response","request_seq":1,"command":"initialize","success":false,"body":{"error":{"id":9221,"format":
    "Error processing initialize: TypeError: Cannot read properties of undefined (reading 'apply')
    at console.<computed> [as assert] (/home/vscode/.vscode-server/extensions/asvetliakov.vscode-neovim-1.18.11/node_modules/neovim/lib/utils/logger.js:72:46)
    at r.onInitialize (/vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:120:345)
    at /vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:119:1632
    at zc._onMessage (/vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:34:4948)
    at /vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:34:3426
    at D.fire (/vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:30:10962)
    at Socket._handleData (/vscode/vscode-server/…/extensions/ms-vscode.js-debug/src/extension.js:116:688)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Socket.Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)","showUser":false,"sendTelemetry":false}}}},"level":0}

9a2cf4ce6674 restored "console.x monkey-patching", but the logic was sloppy: it replaces every console.x function instead of only the ones that our logger actually supports.

## Solution:
- Only patch `console.x` functions we can actually support.
- Special-case `console.assert`.