### PR TITLE
feat: add firstMatch option for findNvim

### DIFF
--- a/packages/neovim/src/utils/findNvim.test.ts
+++ b/packages/neovim/src/utils/findNvim.test.ts
@@ -105,7 +105,7 @@ describe('findNvim', () => {
   });
 
   it('stops searching on first match when stopOnFirstMatch is True', () => {
-    const nvimRes = findNvim({ minVersion: '0.3.0', stopOnFirstMatch: true });
+    const nvimRes = findNvim({ minVersion: '0.3.0', firstMatch: true });
     expect(nvimRes).toEqual({
       matches: expect.any(Array),
       invalid: expect.any(Array),

--- a/packages/neovim/src/utils/findNvim.test.ts
+++ b/packages/neovim/src/utils/findNvim.test.ts
@@ -104,7 +104,7 @@ describe('findNvim', () => {
     });
   });
 
-  it('stops searching on first match when stopOnFirstMatch is True', () => {
+  it('stops searching on first match when firstMatch is True', () => {
     const nvimRes = findNvim({ minVersion: '0.3.0', firstMatch: true });
     expect(nvimRes).toEqual({
       matches: expect.any(Array),

--- a/packages/neovim/src/utils/findNvim.test.ts
+++ b/packages/neovim/src/utils/findNvim.test.ts
@@ -103,4 +103,20 @@ describe('findNvim', () => {
       error: undefined,
     });
   });
+
+  it('stops searching on first match when stopOnFirstMatch is True', () => {
+    const nvimRes = findNvim({ minVersion: '0.3.0', stopOnFirstMatch: true });
+    expect(nvimRes).toEqual({
+      matches: expect.any(Array),
+      invalid: expect.any(Array),
+    });
+    expect(nvimRes.matches.length).toEqual(1);
+    expect(nvimRes.matches[0]).toEqual({
+      nvimVersion: expect.any(String),
+      path: expect.any(String),
+      buildType: expect.any(String),
+      luaJitVersion: expect.any(String),
+      error: undefined,
+    });
+  });
 });


### PR DESCRIPTION
Closes #370 and #267

Introducing a new 'stopOnFirstMatch' option for the findNvim function, which helps reduce the number of system calls when the caller only need one valid match. Additionally, the search now includes common locations where Neovim might be installed.