### PR TITLE
ci: run codecov on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,6 @@ jobs:
         npm run test-build --stream
 
     - uses: codecov/codecov-action@v4
-      if: runner.os == 'macOS'
+      if: matrix.node == '20'
       with:
         verbose: true # optional (default = false)


### PR DESCRIPTION
## Problem:
Code coverage is not counted for Windows. For example, in https://github.com/neovim/node-client/pull/397 codecov flags the `if (LOCALAPPDATA)` branches.

## Solution:
Run codecov on all platforms (but only for a single node version, to be frugal).