### PR TITLE
build(tests): type check Buffer.test.ts

### DIFF
--- a/packages/neovim/tsconfig.json
+++ b/packages/neovim/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./lib"
   },
-  "include": ["src"],
+  "include": ["src", "**/api/Buffer.test.ts"],
   "exclude": ["node_modules", "__tests__", "**/*.test.ts", "examples", "lib"]
 }


### PR DESCRIPTION
ref #352

Our linter and TypeScript config disagreed on test files. Linter included them, config didn't.

https://github.com/neovim/node-client/blob/65ddb5e7c8fa6c1bd4a6cd6564ad0cdf83b7e92c/packages/neovim/tsconfig.json#L7

https://github.com/neovim/node-client/blob/65ddb5e7c8fa6c1bd4a6cd6564ad0cdf83b7e92c/package.json#L37

This PR should fix this as well.