### PR TITLE
test: proc.on('close') event

### DIFF
--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -91,7 +91,7 @@
       "<rootDir>/src/testSetup.ts"
     ],
     "testEnvironment": "node",
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
+    "testRegex": "(/__tests__/.*|attach(\\.|/)(test|spec))\\.ts$",
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageReporters": [


### PR DESCRIPTION
This is a demo for a potential issue noticed in https://github.com/neovim/node-client/pull/414#discussion_r1796637402

# Problem

`proc.on('close')` does not always trigger on `nvim.quit()`. Based on the failures from the test changes in this PR, it appears that sometimes the child (`nvim`) does not close the stderr pipe:

```
    expect(received).toStrictEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Object {
        "errors": 0,
    -   "stderrClosed": true,
    +   "stderrClosed": false,
        "stdoutClosed": true,
      }

      172 |     // TODO: 'close' event sometimes does not emit. #414
      173 |     proc.on('exit', () => {
    > 174 |       expect(r).toStrictEqual({
          |                 ^
      175 |         stdoutClosed: true,
      176 |         stderrClosed: true,
      177 |         errors: 0,

      at ChildProcess.toStrictEqual (src/attach/attach.test.ts:174:17)
```

# Solution

This seems like a potential bug or at least something to document in Nvim itself. I thought it might be related to this: https://github.com/neovim/neovim/blob/c4762b309714897615607f135aab9d7bcc763c4f/src/nvim/channel.c#L168-L171

```c
      // Don't close on exit, in case late error messages
      if (!exiting) {
        fclose(stderr);
      }
```

but, forcing `fclose(stderr)` does not pass the tests in this PR. Nor does adding `fclose(stderr)` anywhere else AFAICT.