### PR TITLE
test: replace jest-mock with sinon, drop expect

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,9 @@ updates:
               patterns:
                   - 'mocha*'
                   - '@types/mocha'
-                  - 'jest*'
+                  - '@types/sinon'
+                  - 'sinon'
                   - 'c8'
-                  - 'expect'
     # Check for updates to GitHub Actions every week
     - package-ecosystem: 'github-actions'
       directory: '/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,18 +2306,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "dependencies": {
-        "jest-get-type": "^29.6.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2504,6 +2492,50 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -2606,10 +2638,19 @@
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
     "node_modules/@types/triple-beam": {
@@ -3737,15 +3778,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4421,22 +4453,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
-    },
-    "node_modules/expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5398,21 +5414,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -5445,55 +5446,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -5665,6 +5617,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -5993,6 +5951,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -6547,6 +6511,19 @@
       "resolved": "packages/neovim",
       "link": true
     },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6860,6 +6837,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7520,6 +7506,33 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7607,27 +7620,6 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/string_decoder": {
@@ -8015,6 +8007,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -8601,10 +8602,10 @@
       },
       "devDependencies": {
         "@types/mocha": "^10.0.9",
+        "@types/sinon": "^17.0.3",
         "c8": "^10.1.2",
-        "expect": "^29.7.0",
-        "jest-mock": "^29.7.0",
-        "mocha": "^10.7.3"
+        "mocha": "^10.7.3",
+        "sinon": "^19.0.2"
       }
     },
     "packages/neovim": {
@@ -8624,10 +8625,10 @@
         "@babel/preset-typescript": "^7.24.7",
         "@types/mocha": "^10.0.9",
         "@types/node": "^16.18.113",
+        "@types/sinon": "^17.0.3",
         "c8": "^10.1.2",
-        "expect": "^29.7.0",
-        "jest-mock": "^29.7.0",
         "mocha": "^10.7.3",
+        "sinon": "^19.0.2",
         "ts-node": "^10.9.2",
         "typedoc": "^0.26.7",
         "typescript": "^5.6.3"
@@ -10233,15 +10234,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@jest/expect-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
-      "requires": {
-        "jest-get-type": "^29.6.3"
-      }
-    },
     "@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -10369,11 +10361,11 @@
       "requires": {
         "@neovim/example-plugin": "file:../example-plugin",
         "@types/mocha": "^10.0.9",
+        "@types/sinon": "^17.0.3",
         "c8": "^10.1.2",
-        "expect": "^29.7.0",
-        "jest-mock": "^29.7.0",
         "mocha": "^10.7.3",
-        "neovim": "file:../neovim"
+        "neovim": "file:../neovim",
+        "sinon": "^19.0.2"
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
@@ -10442,6 +10434,49 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.2.tgz",
+      "integrity": "sha512-4Bb+oqXZTSTZ1q27Izly9lv8B9dlV61CROxPiVtywwzv5SnytJqhvYe6FclHYuXml4cd1VHPo1zd5PmTeJozvA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+          "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
     "@tsconfig/node10": {
@@ -10546,10 +10581,19 @@
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
-    "@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+    "@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
     "@types/triple-beam": {
@@ -11327,12 +11371,6 @@
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true
     },
-    "diff-sequences": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -11832,19 +11870,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
-    },
-    "expect": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
-      "requires": {
-        "@jest/expect-utils": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.7.0",
-        "jest-message-util": "^29.7.0",
-        "jest-util": "^29.7.0"
-      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -12526,18 +12551,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      }
-    },
     "jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -12562,46 +12575,6 @@
         "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "jest-diff": "^29.7.0",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
-      }
-    },
-    "jest-message-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.6.3",
-        "@types/stack-utils": "^2.0.0",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "micromatch": "^4.0.4",
-        "pretty-format": "^29.7.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.3"
-      }
-    },
-    "jest-mock": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "jest-util": "^29.7.0"
       }
     },
     "jest-pnp-resolver": {
@@ -12731,6 +12704,12 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true
     },
     "kuler": {
       "version": "2.0.0",
@@ -12949,6 +12928,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -13368,14 +13353,27 @@
         "@msgpack/msgpack": "^2.8.0",
         "@types/mocha": "^10.0.9",
         "@types/node": "^16.18.113",
+        "@types/sinon": "^17.0.3",
         "c8": "^10.1.2",
-        "expect": "^29.7.0",
-        "jest-mock": "^29.7.0",
         "mocha": "^10.7.3",
+        "sinon": "^19.0.2",
         "ts-node": "^10.9.2",
         "typedoc": "^0.26.7",
         "typescript": "^5.6.3",
         "winston": "3.15.0"
+      }
+    },
+    "nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
       }
     },
     "node-int64": {
@@ -13619,6 +13617,12 @@
           "dev": true
         }
       }
+    },
+    "path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -14077,6 +14081,28 @@
         }
       }
     },
+    "sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+          "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+          "dev": true
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14143,23 +14169,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
-    "stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        }
-      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -14438,6 +14447,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -51,9 +51,9 @@
   ],
   "devDependencies": {
     "@types/mocha": "^10.0.9",
+    "@types/sinon": "^17.0.3",
     "c8": "^10.1.2",
-    "expect": "^29.7.0",
-    "jest-mock": "^29.7.0",
-    "mocha": "^10.7.3"
+    "mocha": "^10.7.3",
+    "sinon": "^19.0.2"
   }
 }

--- a/packages/integration-tests/src/factory.test.ts
+++ b/packages/integration-tests/src/factory.test.ts
@@ -1,5 +1,5 @@
 import { Neovim, NeovimClient, NvimPlugin, loadPlugin } from 'neovim';
-import expect from 'expect';
+import assert from 'node:assert';
 
 function getFakeNvimClient(): NeovimClient {
   const logged: string[] = [];
@@ -47,46 +47,52 @@ describe('Plugin Factory (used by host)', () => {
       { type: 'function', name: 'Func', sync: true, opts: {} },
       { type: 'function', name: 'Global', sync: true, opts: {} },
     ];
-    expect(pluginObj.specs).toEqual(expected);
+    assert.deepStrictEqual(pluginObj.specs, expected);
   });
 
   it('should collect the handlers from a plugin', async () => {
-    expect(await pluginObj.handleRequest('Func', 'function', ['town'])).toEqual(
+    assert.strictEqual(
+      await pluginObj.handleRequest('Func', 'function', ['town']),
       'Funcy town'
     );
   });
 
   it('should load the plugin a sandbox', async () => {
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['loaded'])
-    ).toEqual(true);
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['Buffer'])
-    ).not.toEqual(undefined);
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['process'])
-    ).not.toContain(['chdir', 'exit']);
+    assert.strictEqual(
+      await pluginObj.handleRequest('Global', 'function', ['loaded']),
+      true
+    );
+    assert.notStrictEqual(
+      await pluginObj.handleRequest('Global', 'function', ['Buffer']),
+      undefined
+    );
+    const result = await pluginObj.handleRequest('Global', 'function', [
+      'process',
+    ]);
+
+    // expect(
+    //   await pluginObj.handleRequest('Global', 'function', ['process'])
+    // ).not.toContain(['chdir', 'exit']);
+
+    assert('chdir' in result);
+    assert('exit' in result);
   });
 
   it('should load files required by the plugin in a sandbox', async () => {
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['required'])
-    ).toEqual('you bet!');
-    // expect(
-    // Object.keys(required.globals.process),
-    // ).not.toContain(
-    // ['chdir', 'exit'],
-    // );
+    assert.strictEqual(
+      await pluginObj.handleRequest('Global', 'function', ['required']),
+      'you bet!'
+    );
   });
 
   it('loads plugin with instance of nvim API', () => {
     const nvim = getFakeNvimClient();
     const plugin = loadPlugin('@neovim/example-plugin', nvim);
-    expect(plugin?.nvim).toBe(nvim);
+    assert.strictEqual(plugin?.nvim, nvim);
   });
 
   it('returns null on invalid module', () => {
-    expect(loadPlugin('/asdlfjka/fl', {} as Neovim, {})).toBeNull();
+    assert.strictEqual(loadPlugin('/asdlfjka/fl', {} as Neovim, {}), null);
   });
 });
 
@@ -121,52 +127,58 @@ describe('Plugin Factory (decorator api)', () => {
       { type: 'function', name: 'Func', sync: true, opts: {} },
       { type: 'function', name: 'Global', sync: true, opts: {} },
       { type: 'function', name: 'Illegal', sync: true, opts: {} },
+      { type: 'function', name: 'Umask', sync: true, opts: {} },
     ];
-    expect(pluginObj.specs).toEqual(expect.arrayContaining(expected));
+    assert.deepStrictEqual(pluginObj.specs, expected);
   });
 
   it('should collect the handlers from a plugin', async () => {
-    expect(await pluginObj.handleRequest('Func', 'function', ['town'])).toEqual(
+    assert.strictEqual(
+      await pluginObj.handleRequest('Func', 'function', ['town']),
       'Funcy town'
     );
   });
 
-  it('should load the plugin a sandbox', async () => {
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['loaded'])
-    ).toEqual(true);
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['process'])
-    ).not.toContain(['chdir', 'exit']);
+  it('should load the plugin in a sandbox', async () => {
+    assert.strictEqual(
+      await pluginObj.handleRequest('Global', 'function', ['loaded']),
+      true
+    );
+    const result = await pluginObj.handleRequest('Global', 'function', [
+      'process',
+    ]);
+
+    // expect(
+    //   await pluginObj.handleRequest('Global', 'function', ['process'])
+    // ).not.toContain(['chdir', 'exit']);
+    //
+    assert('chdir' in result);
+    assert('exit' in result);
   });
 
   it('should load files required by the plugin in a sandbox', async () => {
-    expect(
-      await pluginObj.handleRequest('Global', 'function', ['required'])
-    ).toEqual('you bet!');
-    // expect(
-    // Object.keys(required.globals.process),
-    // ).not.toContain(
-    // ['chdir', 'exit'],
-    // );
+    assert.strictEqual(
+      await pluginObj.handleRequest('Global', 'function', ['required']),
+      'you bet!'
+    );
   });
 
   it('loads plugin with instance of nvim API', () => {
     const nvim = getFakeNvimClient();
     const plugin = loadPlugin('@neovim/example-plugin-decorators', nvim, {});
-    expect(plugin!.nvim).toBe(nvim);
+    assert.strictEqual(plugin!.nvim, nvim);
   });
 
   it('cannot call illegal process functions', () => {
     const nvim = getFakeNvimClient();
     const plugin = loadPlugin('@neovim/example-plugin-decorators', nvim, {});
-    expect(plugin!.functions.Illegal.fn).toThrow();
+    assert.throws(() => plugin!.functions.Illegal.fn());
   });
 
   it('can read process.umask()', () => {
     const nvim = getFakeNvimClient();
     const plugin = loadPlugin('@neovim/example-plugin-decorators', nvim, {});
-    expect(() => plugin!.functions.Umask.fn()).not.toThrow();
-    expect(plugin!.functions.Umask.fn()).toBeDefined();
+    assert.doesNotThrow(() => plugin!.functions.Umask.fn());
+    assert.notStrictEqual(plugin!.functions.Umask.fn(), undefined);
   });
 });

--- a/packages/neovim/package.json
+++ b/packages/neovim/package.json
@@ -60,10 +60,10 @@
     "@babel/preset-typescript": "^7.24.7",
     "@types/mocha": "^10.0.9",
     "@types/node": "^16.18.113",
+    "@types/sinon": "^17.0.3",
     "c8": "^10.1.2",
-    "expect": "^29.7.0",
-    "jest-mock": "^29.7.0",
     "mocha": "^10.7.3",
+    "sinon": "^19.0.2",
     "ts-node": "^10.9.2",
     "typedoc": "^0.26.7",
     "typescript": "^5.6.3"

--- a/packages/neovim/src/api/Tabpage.test.ts
+++ b/packages/neovim/src/api/Tabpage.test.ts
@@ -1,5 +1,5 @@
-import * as jestMock from 'jest-mock';
-import expect from 'expect';
+import * as sinon from 'sinon';
+import assert from 'node:assert';
 import * as testUtil from '../testUtil';
 import type { Tabpage } from './Tabpage';
 
@@ -16,7 +16,7 @@ describe('Tabpage API', () => {
 
   it('gets the current Tabpage', async () => {
     const tabpage = await nvim.tabpage;
-    expect(tabpage).toBeInstanceOf(nvim.Tabpage);
+    assert(tabpage instanceof nvim.Tabpage);
   });
 
   describe('Normal API calls', () => {
@@ -29,115 +29,107 @@ describe('Tabpage API', () => {
     after(() => nvim.command('tabclose'));
 
     it('gets the current tabpage number', async () => {
-      expect(await tabpage.number).toBe(1);
+      assert.strictEqual(await tabpage.number, 1);
     });
 
     it('is a valid tabpage', async () => {
-      expect(await tabpage.valid).toBe(true);
+      assert.strictEqual(await tabpage.valid, true);
     });
 
     it('adds a tabpage and switches to it', async () => {
-      nvim.command('tabnew');
+      await nvim.command('tabnew');
 
       // Switch to new tabpage
       const tabpages = await nvim.tabpages;
-      expect(tabpages.length).toBe(2);
+      assert.strictEqual(tabpages.length, 2);
 
       nvim.tabpage = tabpages[tabpages.length - 1];
 
       const newTabPage = await nvim.tabpage;
-      expect(await newTabPage.number).toBe(2);
+      assert.strictEqual(await newTabPage.number, 2);
     });
 
     it('gets current window in tabpage', async () => {
       const window = await tabpage.window;
-
-      expect(window).toBeInstanceOf(nvim.Window);
+      assert(window instanceof nvim.Window);
     });
 
     it('gets list of windows in tabpage', async () => {
       const windows = await tabpage.windows;
-
-      expect(windows.length).toBe(1);
+      assert.strictEqual(windows.length, 1);
 
       // Add a new window
       await nvim.command('vsplit');
 
       const newWindows = await tabpage.windows;
-      expect(newWindows.length).toBe(2);
+      assert.strictEqual(newWindows.length, 2);
     });
 
     it('logs an error when calling `getOption`', () => {
-      const spy = jestMock.spyOn(tabpage.logger, 'error');
+      const spy = sinon.spy(tabpage.logger, 'error');
 
       tabpage.getOption();
-      expect(spy.mock.calls.length).toBe(1);
+      assert.strictEqual(spy.callCount, 1);
 
       tabpage.setOption();
-      expect(spy.mock.calls.length).toBe(2);
-      spy.mockClear();
+      assert.strictEqual(spy.callCount, 2);
     });
 
     it('returns null if variable is not found', async () => {
       const test = await tabpage.getVar('test');
-      expect(test).toBe(null);
+      assert.strictEqual(test, null);
     });
 
     it('can set a t: variable', async () => {
-      tabpage.setVar('test', 'testValue');
+      await tabpage.setVar('test', 'testValue');
 
-      expect(await tabpage.getVar('test')).toBe('testValue');
-
-      expect(await nvim.eval('t:test')).toBe('testValue');
+      assert.strictEqual(await tabpage.getVar('test'), 'testValue');
+      assert.strictEqual(await nvim.eval('t:test'), 'testValue');
     });
 
     it('can delete a t: variable', async () => {
-      tabpage.deleteVar('test');
+      await tabpage.deleteVar('test');
 
-      expect(await nvim.eval('exists("t:test")')).toBe(0);
-
-      expect(await tabpage.getVar('test')).toBe(null);
+      assert.strictEqual(await nvim.eval('exists("t:test")'), 0);
+      assert.strictEqual(await tabpage.getVar('test'), null);
     });
   });
 
   describe('Chainable API calls', () => {
     it('gets the current tabpage number', async () => {
-      expect(await nvim.tabpage.number).toBe(1);
+      assert.strictEqual(await nvim.tabpage.number, 1);
     });
 
     it('is a valid tabpage', async () => {
-      expect(await nvim.tabpage.valid).toBe(true);
+      assert.strictEqual(await nvim.tabpage.valid, true);
     });
 
     it('adds a tabpage and switches to it', async () => {
-      nvim.command('tabnew');
+      await nvim.command('tabnew');
 
       // Switch to new tabpage
       const tabpages = await nvim.tabpages;
-      // TODO
-      expect((await nvim.tabpages).length).toBe(2);
+      assert.strictEqual((await nvim.tabpages).length, 2);
 
       nvim.tabpage = tabpages[tabpages.length - 1];
 
-      expect(await nvim.tabpage.number).toBe(2);
+      assert.strictEqual(await nvim.tabpage.number, 2);
     });
 
     it('gets current window in tabpage', async () => {
       const window = await nvim.tabpage.window;
-
-      expect(window).toBeInstanceOf(nvim.Window);
+      assert(window instanceof nvim.Window);
     });
 
     it('gets list of windows in tabpage', async () => {
       const windows = await nvim.tabpage.windows;
-
-      expect(windows.length).toBe(1);
+      assert.strictEqual(windows.length, 1);
 
       // Add a new window
-      nvim.command('vsplit');
+      await nvim.command('vsplit');
 
-      // TODO
-      expect((await nvim.tabpage.windows).length).toBe(2);
+      // Check the new window count
+      assert.strictEqual((await nvim.tabpage.windows).length, 2);
     });
   });
 });

--- a/packages/neovim/src/plugin/plugin.test.ts
+++ b/packages/neovim/src/plugin/plugin.test.ts
@@ -1,5 +1,5 @@
-import expect from 'expect';
-import * as jestMock from 'jest-mock';
+import assert from 'node:assert';
+import sinon from 'sinon';
 import { plugin as Plugin } from './plugin';
 import { NvimPlugin } from '../host/NvimPlugin';
 import { nvimFunction as FunctionDecorator } from './function';
@@ -22,21 +22,21 @@ describe('Plugin class decorator', () => {
   it('decorates class with no options', () => {
     class MyClass {}
     const plugin = Plugin(MyClass);
-    expect(typeof plugin).toEqual('function');
+    assert(typeof plugin === 'function');
   });
 
   it('decorates class with dev mode option', () => {
     class MyClass {}
 
     const plugin = Plugin({ dev: true })(MyClass);
-    expect(typeof plugin).toEqual('function');
+    assert(typeof plugin === 'function');
 
     const pluginObject = {
-      setOptions: jestMock.fn(),
+      setOptions: sinon.fake(),
       nvim: getFakeNvimClient(),
     };
     instantiateOrRun(plugin, pluginObject);
-    expect(pluginObject.setOptions).toHaveBeenCalledWith({ dev: true });
+    pluginObject.setOptions.calledWith({ dev: true });
   });
 
   it('decorates class methods', () => {
@@ -65,15 +65,15 @@ describe('Plugin class decorator', () => {
     const plugin = Plugin(MyClass);
 
     const pluginObject = {
-      registerAutocmd: jestMock.fn(),
-      registerCommand: jestMock.fn(),
-      registerFunction: jestMock.fn(),
+      registerAutocmd: sinon.fake(),
+      registerCommand: sinon.fake(),
+      registerFunction: sinon.fake(),
       nvim: getFakeNvimClient(),
     };
 
     const instance = instantiateOrRun(plugin, pluginObject);
 
-    expect(pluginObject.registerAutocmd).toHaveBeenCalledWith(
+    pluginObject.registerAutocmd.calledWith(
       'TestAutocmd',
       [instance, MyClass.prototype.testA],
       {
@@ -83,13 +83,13 @@ describe('Plugin class decorator', () => {
       }
     );
 
-    expect(pluginObject.registerCommand).toHaveBeenCalledWith(
+    pluginObject.registerCommand.calledWith(
       'TestCommand',
       [instance, MyClass.prototype.testC],
       { sync: false, range: 'test', nargs: '3' }
     );
 
-    expect(pluginObject.registerFunction).toHaveBeenCalledWith(
+    pluginObject.registerFunction.calledWith(
       'TestF',
       [instance, MyClass.prototype.testF],
       { sync: false, eval: 'test', range: [1, 10] }
@@ -120,7 +120,7 @@ describe('Plugin class decorator', () => {
       getFakeNvimClient()
     );
 
-    expect(pluginObject.specs).toEqual([
+    assert.deepStrictEqual(pluginObject.specs, [
       {
         type: 'autocmd',
         name: 'TestAutocmd',

--- a/packages/neovim/src/testSetup.ts
+++ b/packages/neovim/src/testSetup.ts
@@ -1,11 +1,16 @@
 // Global test setup. Runs before each test.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import sinon from 'sinon';
 import { startNvim, stopNvim } from './testUtil';
 
 export const mochaHooks = {
-  beforeAll: async () => {
+  beforeAll() {
     startNvim();
   },
-  afterAll: () => {
+  beforeEach() {
+    sinon.restore();
+  },
+  afterAll() {
     stopNvim();
   },
 };

--- a/packages/neovim/src/testUtil.ts
+++ b/packages/neovim/src/testUtil.ts
@@ -1,8 +1,6 @@
 import * as cp from 'node:child_process';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import expect from 'expect';
+// import * as fs from 'node:fs';
+// import * as path from 'node:path';
 import { NeovimClient } from './api/client';
 import { attach } from './attach/attach';
 import { findNvim } from './utils/findNvim';
@@ -34,12 +32,12 @@ export function startNvim(
 export function startNvim(
   doAttach: boolean = true
 ): [cp.ChildProcessWithoutNullStreams, NeovimClient | undefined] {
-  const testFile = expect.getState().testPath?.replace(/.*[\\/]/, '');
-  const msg = `startNvim in test: ${testFile}`;
-  if (process.env.NVIM_NODE_LOG_FILE) {
-    const logfile = path.resolve(process.env.NVIM_NODE_LOG_FILE);
-    fs.writeFileSync(logfile, `${msg}\n`, { flag: 'a' });
-  }
+  // const testFile = expect.getState().testPath?.replace(/.*[\\/]/, '');
+  // const msg = `startNvim in test: ${testFile}`;
+  // if (process.env.NVIM_NODE_LOG_FILE) {
+  //   const logfile = path.resolve(process.env.NVIM_NODE_LOG_FILE);
+  //   fs.writeFileSync(logfile, `${msg}\n`, { flag: 'a' });
+  // }
 
   proc = cp.spawn(nvimPath, ['-u', 'NONE', '--embed', '-n', '--noplugin'], {
     cwd: __dirname,

--- a/packages/neovim/src/utils/transport.test.ts
+++ b/packages/neovim/src/utils/transport.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 import * as msgpack from '@msgpack/msgpack';
-import expect from 'expect';
+import assert from 'node:assert';
 import { attach } from '../attach/attach';
 import { exportsForTesting } from './transport';
 
@@ -10,7 +10,8 @@ describe('transport', () => {
     const invalidPayload = { bogus: 'nonsense' };
     const onTransportFail: EventEmitter = exportsForTesting.onTransportFail;
     onTransportFail.on('fail', (errMsg: string) => {
-      expect(errMsg).toEqual(
+      assert.strictEqual(
+        errMsg,
         "invalid msgpack-RPC message: expected array, got: { bogus: 'nonsense' }"
       );
       done();


### PR DESCRIPTION
Follow up #333 .

Remove expect to reduce total number of dependencies, but I found that is hard to use jest-mock without expect, so let's just get rid of it.