### PR TITLE
build: infer prettier parser from file extension

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,8 +1,5 @@
 module.exports = {
-  presets: [
-    ['@babel/preset-env', { targets: { node: '8.15.1' } }],
-    '@babel/preset-typescript',
-  ],
+  presets: [['@babel/preset-env', { targets: { node: '8.15.1' } }], '@babel/preset-typescript'],
   plugins: ['@babel/plugin-proposal-class-properties'],
 
   env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,5 @@
 module.exports = {
-  extends: [
-    'airbnb-base',
-    'plugin:@typescript-eslint/recommended',
-    'prettier',
-  ],
+  extends: ['airbnb-base', 'plugin:@typescript-eslint/recommended', 'prettier'],
   plugins: ['unicorn', 'import', 'prettier', '@typescript-eslint'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
@@ -29,7 +25,10 @@ module.exports = {
         // `jest` against the compiled .js results (would require compiling
         // the test files as well)?
         'unicorn/prefer-at': 'off',
-        'import/no-extraneous-dependencies': ['error', {'devDependencies': true, 'optionalDependencies': false, 'peerDependencies': false}],
+        'import/no-extraneous-dependencies': [
+          'error',
+          { devDependencies: true, optionalDependencies: false, peerDependencies: false },
+        ],
       },
     },
   ],
@@ -65,7 +64,7 @@ module.exports = {
 
     // Causes issues with enums
     'no-shadow': 'off',
-    'prefer-destructuring': 'off',  // Intentionally disabled trash.
+    'prefer-destructuring': 'off', // Intentionally disabled trash.
 
     // prettier things
     'prettier/prettier': 'error',

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,44 +6,44 @@
 
 version: 2
 updates:
-    - package-ecosystem: 'npm'
-      directory: '/' # Location of package manifests.
-      commit-message:
-          prefix: 'deps'
-      schedule:
-          interval: 'weekly'
-      ignore:
-          # @types/node should match our minimum supported node.js version ("engine").
-          - dependency-name: '@types/node'
-      groups:
-          eslint:
-              patterns:
-                  - '@typescript-eslint/*'
-                  - 'eslint*'
-          babel:
-              patterns:
-                  - '@babel/*'
-                  - 'babel*'
-          types:
-              patterns:
-                  - '@types/*'
-              exclude-patterns:
-                  - '@types/node'
-          test:
-              patterns:
-                  - 'mocha*'
-                  - '@types/mocha'
-                  - 'jest*'
-                  - 'c8'
-                  - 'expect'
-    # Check for updates to GitHub Actions every week
-    - package-ecosystem: 'github-actions'
-      directory: '/'
-      commit-message:
-          prefix: 'deps'
-      schedule:
-          interval: 'daily'
-      groups:
-          github-actions:
-              patterns:
-                  - '*'
+  - package-ecosystem: 'npm'
+    directory: '/' # Location of package manifests.
+    commit-message:
+      prefix: 'deps'
+    schedule:
+      interval: 'weekly'
+    ignore:
+      # @types/node should match our minimum supported node.js version ("engine").
+      - dependency-name: '@types/node'
+    groups:
+      eslint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint*'
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel*'
+      types:
+        patterns:
+          - '@types/*'
+        exclude-patterns:
+          - '@types/node'
+      test:
+        patterns:
+          - 'mocha*'
+          - '@types/mocha'
+          - 'jest*'
+          - 'c8'
+          - 'expect'
+  # Check for updates to GitHub Actions every week
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    commit-message:
+      prefix: 'deps'
+    schedule:
+      interval: 'daily'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,77 +22,77 @@ jobs:
         node: ['14', '16', '18', '20']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         exclude:
-        - os: macos-latest
-          node: '14'
-        - os: macos-latest
-          node: '16'
-        - os: windows-latest
-          node: '14'
-        - os: windows-latest
-          node: '16'
+          - os: macos-latest
+            node: '14'
+          - os: macos-latest
+            node: '16'
+          - os: windows-latest
+            node: '14'
+          - os: windows-latest
+            node: '16'
         include:
-        - os: ubuntu-latest
-          NIGHTLY: nvim-linux64.tar.gz
-          NVIM_BIN_PATH: nvim-linux64/bin
-          EXTRACT: tar xzf
-        - os: macos-latest
-          NIGHTLY: nvim-macos-x86_64.tar.gz
-          NVIM_BIN_PATH: nvim-macos-x86_64/bin
-          EXTRACT: tar xzf
-        - os: windows-latest
-          NIGHTLY: nvim-win64.zip
-          NVIM_BIN_PATH: nvim-win64/bin
-          EXTRACT: unzip
+          - os: ubuntu-latest
+            NIGHTLY: nvim-linux64.tar.gz
+            NVIM_BIN_PATH: nvim-linux64/bin
+            EXTRACT: tar xzf
+          - os: macos-latest
+            NIGHTLY: nvim-macos-x86_64.tar.gz
+            NVIM_BIN_PATH: nvim-macos-x86_64/bin
+            EXTRACT: tar xzf
+          - os: windows-latest
+            NIGHTLY: nvim-win64.zip
+            NVIM_BIN_PATH: nvim-win64/bin
+            EXTRACT: unzip
 
     runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
-      with:
-        cache: npm
-        node-version: ${{ matrix.node }}
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: ${{ matrix.node }}
 
-    - name: update npm (for node.js 14)
-      if: matrix.node == '14'
-      run: npm install -g 'npm@^8.8.0'
+      - name: update npm (for node.js 14)
+        if: matrix.node == '14'
+        run: npm install -g 'npm@^8.8.0'
 
-    - name: install neovim
-      run: |
-        curl -LO 'https://github.com/neovim/neovim/releases/download/nightly/${{ matrix.NIGHTLY }}'
-        ${{ matrix.EXTRACT }} ${{ matrix.NIGHTLY }}
-        echo '${{ runner.os }}'
+      - name: install neovim
+        run: |
+          curl -LO 'https://github.com/neovim/neovim/releases/download/nightly/${{ matrix.NIGHTLY }}'
+          ${{ matrix.EXTRACT }} ${{ matrix.NIGHTLY }}
+          echo '${{ runner.os }}'
 
-    - name: update path (bash)
-      if: runner.os != 'Windows'
-      run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" >> $GITHUB_PATH
+      - name: update path (bash)
+        if: runner.os != 'Windows'
+        run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" >> $GITHUB_PATH
 
-    - name: update path (windows)
-      if: runner.os == 'Windows'
-      run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: update path (windows)
+        if: runner.os == 'Windows'
+        run: echo "$(pwd)/${{ matrix.NVIM_BIN_PATH }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-    - name: install dependencies
-      run: npm ci
+      - name: install dependencies
+        run: npm ci
 
-    - name: build
-      run: npm run build
+      - name: build
+        run: npm run build
 
-    - name: lint
-      # Skip on old Node.js, devDependencies use newish JS features.
-      if: matrix.node != '14'
-      run: npm run lint
+      - name: lint
+        # Skip on old Node.js, devDependencies use newish JS features.
+        if: matrix.node != '14'
+        run: npm run lint
 
-    - name: test
-      run: |
-        echo $PATH
-        which nvim
-        nvim --version
+      - name: test
+        run: |
+          echo $PATH
+          which nvim
+          nvim --version
 
-        npm run test-coverage --stream
+          npm run test-coverage --stream
 
-    - uses: codecov/codecov-action@v5
-      if: matrix.node == '20'
-      with:
-        verbose: true # optional (default = false)
+      - uses: codecov/codecov-action@v5
+        if: matrix.node == '20'
+        with:
+          verbose: true # optional (default = false)

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,7 +1,6 @@
 {
   "tabWidth": 2,
   "trailingComma": "es5",
-  "parser": "typescript",
   "printWidth": 100,
   "singleQuote": true,
   "arrowParens": "avoid"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Neovim node.js client
 
-| CI (node >= 14, Linux/macOS/Windows) | Coverage | npm |
-|----------------------------|----------|-----|
+| CI (node >= 14, Linux/macOS/Windows)                                                                                                              | Coverage                               | npm                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------------------- |
 | [![ci](https://github.com/neovim/node-client/actions/workflows/ci.yml/badge.svg)](https://github.com/neovim/node-client/actions/workflows/ci.yml) | [![Coverage Badge][]][Coverage Report] | [![npm version][]][npm package] |
 
 ## Install
@@ -29,9 +29,9 @@ The `neovim` package provides these functions:
 - At load-time, the `neovim` module replaces ("monkey patches") `console` with its `logger`
   interface, so `console.log` will call `logger.info` instead of writing to stdout (which would
   break the stdio RPC channel).
-    - To skip this patching of `console.log`, pass a custom `logger` to `attach()`.
-    - Best practice in any case is to use the `logger` available from the `NeovimClient` returned by
-      `attach()`, instead of `console` logging functions.
+  - To skip this patching of `console.log`, pass a custom `logger` to `attach()`.
+  - Best practice in any case is to use the `logger` available from the `NeovimClient` returned by
+    `attach()`, instead of `console` logging functions.
 - Set the `$NVIM_NODE_LOG_FILE` env var to (also) write logs to a file.
 - Set the `$ALLOW_CONSOLE` env var to (also) write logs to stdout. **This will break any (stdio) RPC
   channel** because logs written to stdout are invalid RPC messages.
@@ -45,57 +45,60 @@ Following is a complete, working example.
    npm install neovim
    ```
 2. Paste the script below into a `demo.mjs` file and run it!
+
    ```
    ALLOW_CONSOLE=1 node demo.mjs
    ```
-    - `$ALLOW_CONSOLE` env var must be set, because logs are normally not printed to stdout.
-        - Note: `$ALLOW_CONSOLE` is only for demo purposes. It cannot be used for remote plugins or
-          whenever stdio is an RPC channel, because writing logs to stdout would break the RPC
-          channel.
-    - Script:
-     ```js
-     import * as child_process from 'node:child_process'
-     import * as assert from 'node:assert'
-     import { attach, findNvim } from 'neovim'
 
-     // Find `nvim` on the system and open a channel to it.
-     (async function() {
-       const found = findNvim({ orderBy: 'desc', minVersion: '0.9.0' })
-       console.log(found);
-       const nvim_proc = child_process.spawn(found.matches[0].path, ['--clean', '--embed'], {});
-       const nvim = attach({ proc: nvim_proc });
+   - `$ALLOW_CONSOLE` env var must be set, because logs are normally not printed to stdout.
+     - Note: `$ALLOW_CONSOLE` is only for demo purposes. It cannot be used for remote plugins or
+       whenever stdio is an RPC channel, because writing logs to stdout would break the RPC
+       channel.
+   - Script:
 
-       nvim.command('vsp | vsp | vsp');
+   ```js
+   import * as child_process from 'node:child_process';
+   import * as assert from 'node:assert';
+   import { attach, findNvim } from 'neovim';
 
-       const windows = await nvim.windows;
-       assert.deepStrictEqual(windows.length, 4);
-       assert.ok(windows[0] instanceof nvim.Window);
+   // Find `nvim` on the system and open a channel to it.
+   (async function () {
+     const found = findNvim({ orderBy: 'desc', minVersion: '0.9.0' });
+     console.log(found);
+     const nvim_proc = child_process.spawn(found.matches[0].path, ['--clean', '--embed'], {});
+     const nvim = attach({ proc: nvim_proc });
 
-       nvim.window = windows[2];
-       const win = await nvim.window;
-       assert.ok(win.id !== windows[0].id);
-       assert.deepStrictEqual(win.id, windows[2].id);
+     nvim.command('vsp | vsp | vsp');
 
-       const buf = await nvim.buffer;
-       assert.ok(buf instanceof nvim.Buffer);
-       const lines = await buf.lines;
-       assert.deepStrictEqual(lines, []);
+     const windows = await nvim.windows;
+     assert.deepStrictEqual(windows.length, 4);
+     assert.ok(windows[0] instanceof nvim.Window);
 
-       await buf.replace(['line1', 'line2'], 0);
-       const newLines = await buf.lines;
-       assert.deepStrictEqual(newLines, ['line1', 'line2']);
+     nvim.window = windows[2];
+     const win = await nvim.window;
+     assert.ok(win.id !== windows[0].id);
+     assert.deepStrictEqual(win.id, windows[2].id);
 
-       if (nvim_proc.disconnect) {
-         nvim_proc.disconnect();
-       }
-       nvim.quit();
-       while (nvim_proc.exitCode === null) {
-         await new Promise(resolve => setTimeout(resolve, 100))
-         console.log('waiting for Nvim (pid %d) to exit', nvim_proc.pid);
-       }
-       console.log('Nvim exit code: %d', nvim_proc.exitCode);
-     })();
-     ```
+     const buf = await nvim.buffer;
+     assert.ok(buf instanceof nvim.Buffer);
+     const lines = await buf.lines;
+     assert.deepStrictEqual(lines, []);
+
+     await buf.replace(['line1', 'line2'], 0);
+     const newLines = await buf.lines;
+     assert.deepStrictEqual(newLines, ['line1', 'line2']);
+
+     if (nvim_proc.disconnect) {
+       nvim_proc.disconnect();
+     }
+     nvim.quit();
+     while (nvim_proc.exitCode === null) {
+       await new Promise(resolve => setTimeout(resolve, 100));
+       console.log('waiting for Nvim (pid %d) to exit', nvim_proc.pid);
+     }
+     console.log('Nvim exit code: %d', nvim_proc.exitCode);
+   })();
+   ```
 
 ### Create a remote plugin
 
@@ -116,7 +119,7 @@ See [`examples/`](https://github.com/neovim/node-client/tree/master/examples) fo
 ### Remote plugin API
 
 ```ts
-  NvimPlugin.nvim
+NvimPlugin.nvim;
 ```
 
 This is the nvim api object you can use to send commands from your plugin to nvim.
@@ -133,7 +136,6 @@ This is the nvim api object you can use to send commands from your plugin to nvi
 Set your plugin to dev mode, which will cause the module to be reloaded on each invocation.
 `alwaysInit` will always attempt to attempt to re-instantiate the plugin. e.g. your plugin class will
 always get called on each invocation of your plugin's command.
-
 
 ```ts
   NvimPlugin.registerAutocmd(name: string, fn: Function, options: AutocmdOptions): void;
@@ -183,23 +185,23 @@ For debugging and configuring logging, you can set the following environment var
 - `NVIM_NODE_HOST_DEBUG`: Spawns the node process that calls `neovim-client-host` with `--inspect-brk` so you can have a debugger.
   Pair that with this [Node Inspector Manager Chrome plugin](https://chrome.google.com/webstore/detail/nodejs-v8-inspector-manag/gnhhdgbaldcilmgcpfddgdbkhjohddkj?hl=en)
 - Logging: Logging is done using `winston` through the `logger` module. This package replaces `console` with this interface.
-    - `NVIM_NODE_LOG_LEVEL`: Sets the logging level for winston. Default is `debug`.
-      Available levels: `{ error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5 }`
-    - `NVIM_NODE_LOG_FILE`: Sets the log file path.
+  - `NVIM_NODE_LOG_LEVEL`: Sets the logging level for winston. Default is `debug`.
+    Available levels: `{ error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5 }`
+  - `NVIM_NODE_LOG_FILE`: Sets the log file path.
 - Usage through node REPL
-    - `NVIM_LISTEN_ADDRESS`:
-        1. Start Nvim with a known address (or use the $NVIM_LISTEN_ADDRESS of a running instance):
-           ```
-           $ NVIM_LISTEN_ADDRESS=/tmp/nvim nvim
-           ```
-        2. In another terminal, connect a node REPL to Nvim
-           ```javascript
-           // `scripts/nvim` will detect if `NVIM_LISTEN_ADDRESS` is set and use that unix socket
-           // Otherwise will create an embedded `nvim` instance
-           require('neovim/scripts/nvim').then((nvim) => {
-             nvim.command('vsp');
-           });
-           ```
+  - `NVIM_LISTEN_ADDRESS`:
+    1. Start Nvim with a known address (or use the $NVIM_LISTEN_ADDRESS of a running instance):
+       ```
+       $ NVIM_LISTEN_ADDRESS=/tmp/nvim nvim
+       ```
+    2. In another terminal, connect a node REPL to Nvim
+       ```javascript
+       // `scripts/nvim` will detect if `NVIM_LISTEN_ADDRESS` is set and use that unix socket
+       // Otherwise will create an embedded `nvim` instance
+       require('neovim/scripts/nvim').then(nvim => {
+         nvim.command('vsp');
+       });
+       ```
 
 See the tests and [`scripts`](https://github.com/neovim/node-client/tree/master/packages/neovim/scripts) for more examples.
 
@@ -261,11 +263,11 @@ git push origin HEAD:gh-pages
 
 ## Contributors
 
-* [@billyvg](https://github.com/billyvg) for rewrite
-* [@mhartington](https://github.com/mhartington) for TypeScript rewrite
-* [@fritzy](https://github.com/fritzy) for transferring over the npm package repo `neovim`!
-* [@rhysd](https://github.com/rhysd), [@tarruda](https://github.com/tarruda), [@nhynes](https://github.com/nhynes) on work for the original `node-client`
-* [@justinmk](https://github.com/justinmk) Neovim maintainer
+- [@billyvg](https://github.com/billyvg) for rewrite
+- [@mhartington](https://github.com/mhartington) for TypeScript rewrite
+- [@fritzy](https://github.com/fritzy) for transferring over the npm package repo `neovim`!
+- [@rhysd](https://github.com/rhysd), [@tarruda](https://github.com/tarruda), [@nhynes](https://github.com/nhynes) on work for the original `node-client`
+- [@justinmk](https://github.com/justinmk) Neovim maintainer
 
 [Coverage Badge]: https://codecov.io/gh/neovim/node-client/branch/master/graph/badge.svg
 [Coverage Report]: https://codecov.io/gh/neovim/node-client

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 ## Examples
 
 To set up an example:
+
 1. Link (or move) the plugin into `/path/to/rplugin/node`
 2. Inside of the plugin directory, run `npm install` or `yarn`
 3. Run `:UpdateRemotePlugins` and restart Neovim

--- a/examples/class.md
+++ b/examples/class.md
@@ -13,10 +13,9 @@ class MyPlugin {
   }
 }
 
-module.exports = (plugin) => new MyPlugin(plugin);
+module.exports = plugin => new MyPlugin(plugin);
 
 // Or for convenience, exporting the class itself is equivalent to the above
 
 module.exports = MyPlugin;
 ```
-

--- a/examples/decorators.md
+++ b/examples/decorators.md
@@ -8,7 +8,6 @@ import { Plugin, Function, Autocmd, Command } from 'neovim';
 // If `Plugin` decorator can be called with options
 @Plugin({ dev: true })
 export default class TestPlugin {
-
   constructor(nvim, plugin) {}
 
   @Function('Vsplit', { sync: true })
@@ -25,11 +24,9 @@ export default class TestPlugin {
 
   @Command('UsePromises')
   promiseExample() {
-    return this.nvim.buffer.name.then((name) => {
+    return this.nvim.buffer.name.then(name => {
       console.log(`Current buffer name is ${name}`);
     });
   }
 }
 ```
-
-

--- a/examples/functional.md
+++ b/examples/functional.md
@@ -7,8 +7,7 @@ function onBufWrite() {
   console.log('Buffer written!');
 }
 
-module.exports = (plugin) => {
+module.exports = plugin => {
   plugin.registerAutocmd('BufWritePre', onBufWrite, { pattern: '*' });
 };
 ```
-

--- a/examples/prototype.md
+++ b/examples/prototype.md
@@ -18,4 +18,3 @@ export default MyPlugin;
 
 export default (plugin) => new MyPlugin(plugin);
 ```
-

--- a/examples/rplugin/node/nvim-example/index.js
+++ b/examples/rplugin/node/nvim-example/index.js
@@ -1,20 +1,33 @@
 module.exports = plugin => {
   plugin.setOptions({ dev: false });
 
-  plugin.registerCommand('EchoMessage', async () => {
+  plugin.registerCommand(
+    'EchoMessage',
+    async () => {
       try {
         await plugin.nvim.outWrite('Dayman (ah-ah-ah) \n');
       } catch (err) {
         console.error(err);
       }
-    }, { sync: false });
+    },
+    { sync: false }
+  );
 
-  plugin.registerFunction('SetLines',() => {
-    return plugin.nvim.setLine('May I offer you an egg in these troubling times')
-      .then(() => console.log('Line should be set'))
-  }, {sync: false})
+  plugin.registerFunction(
+    'SetLines',
+    () => {
+      return plugin.nvim
+        .setLine('May I offer you an egg in these troubling times')
+        .then(() => console.log('Line should be set'));
+    },
+    { sync: false }
+  );
 
-  plugin.registerAutocmd('BufEnter', async (fileName) => {
-    await plugin.nvim.buffer.append('BufEnter for a JS File?')
-  }, {sync: false, pattern: '*.js', eval: 'expand("<afile>")'})
+  plugin.registerAutocmd(
+    'BufEnter',
+    async fileName => {
+      await plugin.nvim.buffer.append('BufEnter for a JS File?');
+    },
+    { sync: false, pattern: '*.js', eval: 'expand("<afile>")' }
+  );
 };

--- a/packages/example-plugin-decorators/src/index.js
+++ b/packages/example-plugin-decorators/src/index.js
@@ -4,12 +4,7 @@ required = require('./fixture');
 // Hack to get global object
 const global = Function('return this')();
 
-const {
-  Plugin,
-  Function: NvimFunction,
-  Autocmd,
-  Command,
-} = require('@neovim/decorators');
+const { Plugin, Function: NvimFunction, Autocmd, Command } = require('@neovim/decorators');
 
 @Plugin
 class Test {

--- a/packages/integration-tests/__tests__/integration.test.ts
+++ b/packages/integration-tests/__tests__/integration.test.ts
@@ -16,17 +16,7 @@ describe('Node host', () => {
   before(async () => {
     const plugdir = path.resolve(__dirname);
     const nvimrc = path.join(plugdir, 'nvimrc');
-    args = [
-      '-u',
-      nvimrc,
-      '--headless',
-      '-i',
-      'NONE',
-      '-c',
-      'UpdateRemotePlugins',
-      '-c',
-      'q!',
-    ];
+    args = ['-u', nvimrc, '--headless', '-i', 'NONE', '-c', 'UpdateRemotePlugins', '-c', 'q!'];
 
     const integrationDir = path.resolve(plugdir, '..', '..', 'example-plugin');
     process.chdir(plugdir);
@@ -47,11 +37,7 @@ describe('Node host', () => {
 
     cp.spawnSync(nvimPath, args);
 
-    proc = cp.spawn(
-      nvimPath,
-      ['-u', nvimrc, '-i', 'NONE', '--headless', '--embed', '-n'],
-      {}
-    );
+    proc = cp.spawn(nvimPath, ['-u', nvimrc, '-i', 'NONE', '--headless', '--embed', '-n'], {});
     nvim = attach({ proc });
   });
 
@@ -130,9 +116,7 @@ describe('Node host', () => {
             const debugData = JSON.parse(rawData);
             childHost.kill();
             expect(Array.isArray(debugData) && debugData.length).toBeTruthy();
-            expect(debugData[0].webSocketDebuggerUrl).toMatch(
-              'ws://127.0.0.1:9229'
-            );
+            expect(debugData[0].webSocketDebuggerUrl).toMatch('ws://127.0.0.1:9229');
             done();
           } catch (e: any) {
             // eslint-disable-next-line no-console

--- a/packages/neovim/.mocharc.js
+++ b/packages/neovim/.mocharc.js
@@ -4,5 +4,5 @@ module.exports = {
   require: ['ts-node/register', 'src/testSetup.ts'],
   extension: ['ts'],
   spec: ['src/**/*.test.ts'],
-  exit: true
-}
+  exit: true,
+};

--- a/packages/neovim/bin/cli.js
+++ b/packages/neovim/bin/cli.js
@@ -14,8 +14,8 @@ if (args[0] === '--version') {
 }
 
 // "21.6.1" => "21"
-const nodeMajorVersionStr = process.versions.node.replace(/\..*/, '')
-const nodeMajorVersion = Number.parseInt(nodeMajorVersionStr ? nodeMajorVersionStr : '0')
+const nodeMajorVersionStr = process.versions.node.replace(/\..*/, '');
+const nodeMajorVersion = Number.parseInt(nodeMajorVersionStr ? nodeMajorVersionStr : '0');
 
 if (
   process.env.NVIM_NODE_HOST_DEBUG &&

--- a/packages/neovim/bin/generate-typescript-interfaces.js
+++ b/packages/neovim/bin/generate-typescript-interfaces.js
@@ -55,9 +55,7 @@ async function main() {
   process.stdout.write('  proc?: NodeJS.ChildProcess,\n');
   process.stdout.write('  socket?: String,\n');
   process.stdout.write('}\n');
-  process.stdout.write(
-    'export default function attach(options: AttachOptions): Neovim;\n\n'
-  );
+  process.stdout.write('export default function attach(options: AttachOptions): Neovim;\n\n');
 
   Object.keys(interfaces).forEach(key => {
     let name = key;

--- a/packages/neovim/scripts/findMissingApi.js
+++ b/packages/neovim/scripts/findMissingApi.js
@@ -49,24 +49,14 @@ const hasApiMethod = name => {
     .replace(/_([a-z])/g, g => g[1].toUpperCase())
     .replace(/buf/g, 'buffer')
     .replace(/win/g, 'window');
-  const titleMethodName = `${methodName[0].toUpperCase()}${methodName.slice(
-    1
-  )}`;
+  const titleMethodName = `${methodName[0].toUpperCase()}${methodName.slice(1)}`;
 
-  const Constructor =
-    (mappedConstructor && mappedConstructor.constructor) || Neovim;
+  const Constructor = (mappedConstructor && mappedConstructor.constructor) || Neovim;
 
-  const descriptor = Object.getOwnPropertyDescriptor(
-    Constructor.prototype,
-    methodName
-  );
+  const descriptor = Object.getOwnPropertyDescriptor(Constructor.prototype, methodName);
 
   // check property descriptors
-  if (
-    descriptor &&
-    ((isSetter && descriptor.set) || (isGetter && descriptor.get))
-  )
-    return true;
+  if (descriptor && ((isSetter && descriptor.set) || (isGetter && descriptor.get))) return true;
 
   // check methods
   if (
@@ -79,8 +69,7 @@ const hasApiMethod = name => {
       .filter(v => !!v)
       .find(
         variation =>
-          variation in Constructor.prototype ||
-          Constructor.prototype.hasOwnProperty(variation)
+          variation in Constructor.prototype || Constructor.prototype.hasOwnProperty(variation)
       )
   ) {
     return true;


### PR DESCRIPTION
Issue
=====

The prettier parser was set to `typescript` in the `.prettierrc.json` file. Because prettier was used for multiple files types, it caused errors when formatting files that were not TypeScript.

Here is an example:

```sh
README.md
[error] README.md: SyntaxError: Invalid character. (1:1)
[error] > 1 | # Neovim node.js client
[error]     | ^
[error]   2 |
[error]   3 | | CI (node >= 14, Linux/macOS/Windows) | Coverage | npm |
[error]   4 | |----------------------------|----------|-----|
```

This seems to cause the build to fail as of the most recent commit https://github.com/neovim/node-client/commit/74880148636620f3f76e0a568aed10ce18b512a1

Solution
========

Automatically infer the parser based on the file extension.

References:
- https://prettier.io/docs/en/configuration.html#setting-the-parserdocsenoptionshtmlparser-option

To make the build pass, run `npx prettier --write .` to format all files. I think it's best that someone else does this, as it will change the formatting of many files (currently 43), and reviewing them is very difficult.