### PR TITLE
chore: fix eslint error about missing neovim pkg in integration-tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8604,7 +8604,8 @@
         "c8": "^10.1.2",
         "expect": "^29.7.0",
         "jest-mock": "^29.7.0",
-        "mocha": "^10.7.3"
+        "mocha": "^10.7.3",
+        "neovim": "file:../neovim"
       }
     },
     "packages/neovim": {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -54,6 +54,7 @@
     "c8": "^10.1.2",
     "expect": "^29.7.0",
     "jest-mock": "^29.7.0",
-    "mocha": "^10.7.3"
+    "mocha": "^10.7.3",
+    "neovim": "file:../neovim"
   }
 }


### PR DESCRIPTION
The following error was reported by eslint:

```sh
❯ npm run lint
...
/Users/mikavilpas/git/neovim-node-client/packages/integration-tests/src/factory.test.ts:1:62: Unable to resolve path to module 'neovim'. [Error/import/no-unresolved]

1 problem
```