### PR TITLE
Use prettier for formatting instead of eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,25 @@
+/**
+ * @type {import('eslint').Linter.LegacyConfig}
+ */
 module.exports = {
   extends: ['airbnb-base', 'plugin:@typescript-eslint/recommended', 'prettier'],
-  plugins: ['unicorn', 'import', 'prettier', '@typescript-eslint'],
+  plugins: ['unicorn', 'import', '@typescript-eslint'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: './tsconfig.json',
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
+  ignorePatterns: [
+    '.eslintrc.js',
+    'packages/*/lib/',
+    'packages/*/bin/',
+    'packages/neovim/scripts/',
+    'packages/integration-tests/__tests__/',
+    'examples/rplugin/node/',
+    'packages/example-plugin/',
+    'packages/example-plugin-decorators/',
+  ],
   env: {
     node: true,
     es2024: true,
@@ -65,9 +78,6 @@ module.exports = {
     // Causes issues with enums
     'no-shadow': 'off',
     'prefer-destructuring': 'off', // Intentionally disabled trash.
-
-    // prettier things
-    'prettier/prettier': 'error',
 
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
+  reportUnusedDisableDirectives: true,
   ignorePatterns: [
     '.eslintrc.js',
     'packages/*/lib/',

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# some tests seem to create these files in CI
+nvim-win64

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-unicorn": "^50.0.1",
         "husky": "^9.1.4",
         "lint-staged": "^15.2.10",
@@ -2470,18 +2469,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
     "node_modules/@shikijs/core": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.16.2.tgz",
@@ -4142,36 +4129,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": "*",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-unicorn": {
       "version": "50.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-50.0.1.tgz",
@@ -4442,12 +4399,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -6942,18 +6893,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -7803,22 +7742,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/synckit": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
-      "dev": true,
-      "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -7998,12 +7921,6 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10417,12 +10334,6 @@
       "dev": true,
       "optional": true
     },
-    "@pkgr/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "dev": true
-    },
     "@shikijs/core": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.16.2.tgz",
@@ -11706,16 +11617,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-      "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.6"
-      }
-    },
     "eslint-plugin-unicorn": {
       "version": "50.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-50.0.1.tgz",
@@ -11851,12 +11752,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -13669,15 +13564,6 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true
     },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
-    },
     "pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -14285,16 +14171,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "synckit": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
-      "dev": true,
-      "requires": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      }
-    },
     "test-exclude": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -14424,12 +14300,6 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unicorn": "^50.0.1",
     "husky": "^9.1.4",
     "lint-staged": "^15.2.10",
@@ -34,7 +33,8 @@
     "test-staged": "npm run test-staged --workspaces --if-present -- --",
     "test-missing-apis": "npm run test-missing-apis --workspaces --if-present",
     "test-lint": "npm run lint",
-    "lint": "eslint --format=unix packages/*/src/**/*.ts packages/*/src/*.ts"
+    "lint": "prettier --check . && eslint --format=unix .",
+    "fixlint": "prettier --write . && eslint --fix --format=unix ."
   },
   "husky": {
     "hooks": {
@@ -43,7 +43,7 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "eslint --fix",
+      "npm run fixlint",
       "npm run test-staged"
     ]
   },

--- a/packages/decorators/src/plugin/plugin.ts
+++ b/packages/decorators/src/plugin/plugin.ts
@@ -96,15 +96,13 @@ function wrapper(cls: PluginWrapperConstructor, options?: PluginOptions): any {
 }
 
 // Can decorate a class with options object
-// eslint-disable-next-line import/export
+
 export function Plugin(
   outter: any
 ): (cls: PluginWrapperConstructor, options?: PluginOptions) => any;
 
-// eslint-disable-next-line import/export
 export function Plugin(outter: any): any;
 
-// eslint-disable-next-line import/export
 export function Plugin(outter: any): any {
   /**
    * Decorator should support

--- a/packages/neovim/src/api/Neovim.ts
+++ b/packages/neovim/src/api/Neovim.ts
@@ -9,23 +9,23 @@ import { ApiInfo } from '../types/ApiInfo';
 export interface UiAttachOptions {
   rgb?: boolean;
   override?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_cmdline?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_hlstate?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_linegrid?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_messages?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_multigrid?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_popupmenu?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_tabline?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_wildmenu?: boolean;
-  // eslint-disable-next-line camelcase
+
   ext_termcolors?: boolean;
 }
 
@@ -56,7 +56,7 @@ export interface Command {
   nargs: string;
   range: string;
   name: string;
-  // eslint-disable-next-line camelcase
+
   script_id: number;
   bar: boolean;
   register: boolean;
@@ -65,7 +65,7 @@ export interface Command {
   complete?: null;
   addr?: any;
   count?: any;
-  // eslint-disable-next-line camelcase
+
   complete_arg?: any;
 }
 

--- a/packages/neovim/src/api/utils/createChainableApi.ts
+++ b/packages/neovim/src/api/utils/createChainableApi.ts
@@ -81,7 +81,6 @@ export function createChainableApi(
     },
 
     set: (target: any, prop: string, value: any, receiver: Promise<any>) => {
-      // eslint-disable-next-line no-param-reassign
       if (receiver && (receiver instanceof Promise || 'then' in receiver)) {
         receiver.then(obj => {
           if (prop in obj) {

--- a/packages/neovim/src/host/NvimPlugin.ts
+++ b/packages/neovim/src/host/NvimPlugin.ts
@@ -9,7 +9,7 @@ export interface NvimPluginOptions {
 
 export interface AutocmdOptions {
   pattern?: string;
-  // eslint-disable-next-line no-eval
+
   eval?: string;
   sync?: boolean;
 }
@@ -24,7 +24,7 @@ export interface CommandOptions {
 export interface NvimFunctionOptions {
   sync?: boolean;
   range?: string;
-  // eslint-disable-next-line no-eval
+
   eval?: string;
 }
 

--- a/packages/neovim/src/plugin/autocmd.ts
+++ b/packages/neovim/src/plugin/autocmd.ts
@@ -2,7 +2,7 @@ import { NVIM_SYNC, NVIM_SPEC, NVIM_METHOD_NAME } from './properties';
 
 export interface AutocmdOptions {
   pattern: string;
-  // eslint-disable-next-line no-eval
+
   eval?: string;
   sync?: boolean;
 }

--- a/packages/neovim/src/plugin/function.ts
+++ b/packages/neovim/src/plugin/function.ts
@@ -3,7 +3,7 @@ import { NVIM_SYNC, NVIM_SPEC, NVIM_METHOD_NAME } from './properties';
 export interface NvimFunctionOptions {
   sync?: boolean;
   range?: [number, number];
-  // eslint-disable-next-line no-eval
+
   eval?: string;
 }
 

--- a/packages/neovim/src/types/Spec.ts
+++ b/packages/neovim/src/types/Spec.ts
@@ -5,7 +5,7 @@ export interface Spec {
   opts: {
     range?: string;
     nargs?: string;
-    // eslint-disable-next-line no-eval
+
     eval?: string;
     pattern?: string;
     complete?: string;


### PR DESCRIPTION
- `npm run lint` now checks formatting with prettier and eslint as discussed in #445 
- `npm run fixlint` now fixes formatting with `prettier --write` and `eslint --fix`
- lint-staged also uses `npm run fixlint` to keep things consistent
- ci seems to already check formatting with prettier and eslint
- added jsdoc type hints to the eslintrc.js file for autocompletion

Eslint now uses a blocklist instead of allowlist for ignoring files. It might be easier to not
accidentally ignore any new files with this approach.

Solves #445