### PR TITLE
feat: add public close methods

### DIFF
--- a/packages/neovim/src/api/client.ts
+++ b/packages/neovim/src/api/client.ts
@@ -6,6 +6,7 @@ import { Transport } from '../utils/transport';
 import { VimValue } from '../types/VimValue';
 import { Neovim } from './Neovim';
 import { Buffer } from './Buffer';
+import { ASYNC_DISPOSE_SYMBOL } from '../utils/util';
 
 const REGEX_BUF_EVENT = /nvim_buf_(.*)_event/;
 
@@ -248,5 +249,16 @@ export class NeovimClient extends Neovim {
     }
 
     return false;
+  }
+
+  async close(): Promise<void> {
+    await this.transport.close();
+  }
+
+  /**
+   * @see close
+   */
+  async [ASYNC_DISPOSE_SYMBOL](): Promise<void> {
+    await this.close();
   }
 }

--- a/packages/neovim/src/utils/transport.test.ts
+++ b/packages/neovim/src/utils/transport.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { Readable, Writable } from 'node:stream';
+import { PassThrough, Readable, Writable } from 'node:stream';
 import * as msgpack from '@msgpack/msgpack';
 import expect from 'expect';
 import { attach } from '../attach/attach';
@@ -26,5 +26,17 @@ describe('transport', () => {
     // Simulate an invalid message on the channel.
     const msg = msgpack.encode(invalidPayload);
     fakeReader.push(Buffer.from(msg.buffer, msg.byteOffset, msg.byteLength));
+  });
+
+  it('closes transport and cleans up pending requests', async () => {
+    const socket = new PassThrough();
+
+    const nvim = attach({ reader: socket, writer: socket });
+
+    // Close the transport
+    const closePromise = nvim.close();
+
+    // Verify close promise resolves
+    await expect(closePromise).resolves.toBeUndefined();
   });
 });

--- a/packages/neovim/src/utils/util.ts
+++ b/packages/neovim/src/utils/util.ts
@@ -41,3 +41,9 @@ export function partialClone(
 
   return clonedObj;
 }
+
+/**
+ * Polyfill for Symbol.asyncDispose if not available in the runtime.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncDispose
+ */
+export const ASYNC_DISPOSE_SYMBOL = Symbol.asyncDispose ?? Symbol.for('Symbol.asyncDispose');


### PR DESCRIPTION
Add method to close transport and writer.

Before there was no public way to close the transport/reader/writer created by attach for a socket, and the connection would hold the node process open.

For example, this script would not exit (without an explicit process.exit(0))
```
attach({ socket: pathToNvimSocket })
```

This change adds .close to transport and NeovimClient which ends the writer. The other side of the connection should then close the reader which triggers detach and the cleanup code.

I added asyncDispose methods for folks using modern javascript runtimes that support explicit resource management:

```
await using client = attach({ socket: pathToNvimSocket })
```

Other wise you can call close
```
try {
  const client = attach({ socket: pathToNvimSocket })
} finally {
  await client.close()
}
```

fix https://github.com/neovim/node-client/issues/481